### PR TITLE
Use `Cargo.toml` to generate `clap` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["Gevulot Team"]
 repository = "https://github.com/gevulotnetwork/gvltctl"
+description = "Gevulot Control CLI"
 
 [dependencies]
 # TODO: change rev to tag when available

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::io::{self, Read, Write};
 mod builders;
 mod commands;
 
-use commands::{build::*, pins::*, tasks::*, workers::*, sudo::*};
+use commands::{build::*, pins::*, sudo::*, tasks::*, workers::*};
 
 /// Main entry point for the Gevulot Control CLI application.
 ///
@@ -124,10 +124,7 @@ fn setup_command_line_args() -> Result<Command, Box<dyn std::error::Error>> {
             .action(ArgAction::Set),
     ];
 
-    Ok(Command::new("gvltctl")
-        .version("1.0")
-        .author("Author Name <author@example.com>")
-        .about("Gevulot Control CLI")
+    Ok(clap::command!()
         .subcommand_required(true)
         // Worker subcommand
         .subcommand(


### PR DESCRIPTION
This will use binary name, version, description etc. from `Cargo.toml` when creating `clap::Command`.