### PR TITLE
Builder: change root filesystem default mode to read-only

### DIFF
--- a/src/builders/mod.rs
+++ b/src/builders/mod.rs
@@ -22,6 +22,7 @@ pub struct BuildOptions {
     pub no_default_mounts: bool,
     pub init: Option<String>,
     pub init_args: Option<String>,
+    pub rw_root: bool,
     pub mbr_file: Option<String>,
     pub output_file: String,
     pub force: bool,
@@ -111,6 +112,7 @@ impl std::fmt::Display for BuildOptions {
                 .as_deref()
                 .unwrap_or("None (will use ENTRYPOINT and CMD)")
         )?;
+        writeln!(f, "| Read-only root   | {:<42} |", !self.rw_root)?;
         writeln!(
             f,
             "| MBR File         | {:<42} |",
@@ -161,6 +163,7 @@ impl TryFrom<&clap::ArgMatches> for BuildOptions {
             no_default_mounts: matches.get_flag("no_default_mounts"),
             init: matches.get_one::<String>("init").cloned(),
             init_args: matches.get_one::<String>("init_args").cloned(),
+            rw_root: matches.get_flag("rw_root"),
             mbr_file: matches.get_one::<String>("mbr_file").cloned(),
             output_file: matches
                 .get_one::<String>("output_file")

--- a/src/builders/skopeo_builder.rs
+++ b/src/builders/skopeo_builder.rs
@@ -140,6 +140,7 @@ impl ImageBuilder for SkopeoSyslinuxBuilder {
                 options.init.as_deref(),
                 init_args.as_deref(),
                 &options.output_file,
+                options.rw_root,
                 options.mbr_file.as_deref(),
             )?;
             print(&format!("✅\n"))?;
@@ -713,6 +714,7 @@ impl SkopeoSyslinuxBuilder {
         init: Option<&str>,
         init_args: Option<&str>,
         output_file: &str,
+        rw_root: bool,
         mbr_file: Option<&str>,
     ) -> Result<()> {
         let init = if let Some(init) = init {
@@ -727,6 +729,8 @@ impl SkopeoSyslinuxBuilder {
             "".to_string()
         };
 
+        let root_dev_mode = if rw_root { "rw" } else { "ro" };
+
         // Create SYSLINUX configuration
         let syslinux_cfg = format!(
             r#"DEFAULT linux
@@ -735,9 +739,9 @@ TIMEOUT 50
 
 LABEL linux
     LINUX /bzImage
-    APPEND root=/dev/sda2 rw console=ttyS0{} {}
+    APPEND root=/dev/sda2 {} console=ttyS0{} {}
 "#,
-            init, init_args
+            root_dev_mode, init, init_args
         );
 
         // Write SYSLINUX configuration to file

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -142,6 +142,17 @@ pub fn get_command() -> clap::Command {
                 .required(false),
         )
         .arg(
+            Arg::new("rw_root")
+                .long("rw-root")
+                .help("Mount root filesystem as read-write. Only for debug purposes.")
+                .long_help("Mount root filesystem as read-write. Only for debug purposes.\n\
+                            Root filesystem will be mounted as read-only by default.\n\
+                            Note: Gevulot worker node will execute your disk image in read-only mode.\n\
+                            This means that images with this flag enabled cannot be executed on the network.")
+                .required(false)
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
             Arg::new("mbr_file")
                 .long("mbr-file")
                 .value_name("FILE")


### PR DESCRIPTION
Worker node will pass image with `readonly=on`. This requires root fs to be mounted as `ro`. Otherwise there will be kernel panic on boot:

```
[    1.142799] /dev/root: Can't open blockdev
[    1.143454] VFS: Cannot open root device "/dev/sda2" or unknown-block(8,2): error -30
```

Added `--rw-root` flag to `gvltctl build` just in case. This flag probably won't be used ever and may be removed in the future.