### PR TITLE
Add `/usr/share/syslinux/mbr.bin` to search path

### DIFF
--- a/src/builders/skopeo_builder.rs
+++ b/src/builders/skopeo_builder.rs
@@ -715,7 +715,8 @@ LABEL linux
         let mbr_path = if let Some(mbr_file) = mbr_file {
             mbr_file
         } else {
-            const CANDIDATES: [&str; 2] = [
+            const CANDIDATES: [&str; 3] = [
+                "/usr/share/syslinux/mbr.bin",
                 "/usr/lib/syslinux/mbr/mbr.bin",
                 "/usr/lib/syslinux/bios/mbr.bin",
             ];

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -171,6 +171,7 @@ pub fn get_command() -> clap::Command {
                 .value_name("FILE")
                 .value_hint(ValueHint::FilePath)
                 .help("Path to MBR file. If none provided, following paths will be tried:\n\
+                        - /usr/share/syslinux/mbr.bin\n\
                         - /usr/lib/syslinux/mbr/mbr.bin\n\
                         - /usr/lib/syslinux/bios/mbr.bin")
                 .required(false),


### PR DESCRIPTION
On Fedora the default syslinux MBR binary is under `/usr/share` instead of `/usr/lib` so add it to the search path.