### PR TITLE
build: subcommand compiled only for Linux targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,23 +9,26 @@ description = "Gevulot Control CLI"
 [dependencies]
 # TODO: change rev to tag when available
 gevulot-rs = { git = "https://github.com/gevulotnetwork/gevulot-rs.git", rev = "091f9fd806b6b7e04968cede8b14f3f4865c98dc" }
-mia-rt-config = { git = "https://github.com/gevulotnetwork/mia.git", tag = "v0.2.0" }
-mia-installer = { git = "https://github.com/gevulotnetwork/mia.git", tag = "v0.2.0" }
 
-anyhow = "1"
 bip32 = "0.5.1"
 clap = { version = "4", features = ["env", "cargo"] }
 clap_complete = "4.5.13"
 cosmrs = "0.20"
 env_logger = "0.11.5"
-log = "0.4.22"
-num_cpus = "1.16.0"
-oci-spec = "0.7.0"
 rand_core = "0.6.4"
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.9.34"
-tempdir = "0.3.7"
-thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 toml = "0.8.19"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+mia-rt-config = { git = "https://github.com/gevulotnetwork/mia.git", tag = "v0.2.0" }
+mia-installer = { git = "https://github.com/gevulotnetwork/mia.git", tag = "v0.2.0" }
+
+anyhow = "1"
+log = "0.4.22"
+num_cpus = "1.16.0"
+oci-spec = "0.7.0"
+tempdir = "0.3.7"
+thiserror = "1"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "linux")]
 pub mod build;
 pub mod pins;
 pub mod tasks;


### PR DESCRIPTION
Using conditional compilation to make `build` subcommand available only for Linux targets