### PR TITLE
Fix private key password handling in commands

### DIFF
--- a/src/commands/sudo.rs
+++ b/src/commands/sudo.rs
@@ -1,5 +1,5 @@
 use gevulot_rs::proto::gevulot::gevulot::{
-    MsgSudoDeletePin, MsgSudoDeleteWorker, MsgSudoDeleteTask, MsgSudoFreezeAccount,
+    MsgSudoDeletePin, MsgSudoDeleteTask, MsgSudoDeleteWorker, MsgSudoFreezeAccount,
 };
 
 use crate::connect_to_gevulot;
@@ -8,7 +8,7 @@ const OK: &str = "ok";
 
 use clap::{Arg, Command, ValueHint};
 
-pub fn get_command() -> clap::Command {
+pub fn get_command(chain_args: &[Arg]) -> clap::Command {
     Command::new("sudo")
         .about("Perform administrative operations with sudo privileges")
         .subcommand_required(true)
@@ -22,7 +22,8 @@ pub fn get_command() -> clap::Command {
                         .required(true)
                         .index(1)
                         .value_hint(ValueHint::Other),
-                ),
+                )
+                .args(chain_args),
         )
         .subcommand(
             Command::new("delete-worker")
@@ -34,7 +35,8 @@ pub fn get_command() -> clap::Command {
                         .required(true)
                         .index(1)
                         .value_hint(ValueHint::Other),
-                ),
+                )
+                .args(chain_args),
         )
         .subcommand(
             Command::new("delete-task")
@@ -46,7 +48,8 @@ pub fn get_command() -> clap::Command {
                         .required(true)
                         .index(1)
                         .value_hint(ValueHint::Other),
-                ),
+                )
+                .args(chain_args),
         )
         .subcommand(
             Command::new("freeze-account")
@@ -58,10 +61,10 @@ pub fn get_command() -> clap::Command {
                         .required(true)
                         .index(1)
                         .value_hint(ValueHint::Other),
-                ),
+                )
+                .args(chain_args),
         )
 }
-
 
 /// Deletes a pin using sudo privileges.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,14 @@ fn setup_command_line_args() -> Result<Command, Box<dyn std::error::Error>> {
             .help("Sets the mnemonic for the Gevulot client")
             .value_hint(ValueHint::Other)
             .action(ArgAction::Set),
+        Arg::new("password")
+            .short('n')
+            .long("password")
+            .value_name("PASSWORD")
+            .env("GEVULOT_PASSWORD")
+            .help("Sets the password for the Gevulot client")
+            .value_hint(ValueHint::Other)
+            .action(ArgAction::Set),
         Arg::new("format")
             .short('F')
             .long("format")
@@ -337,6 +345,7 @@ fn setup_command_line_args() -> Result<Command, Box<dyn std::error::Error>> {
                     Arg::new("password")
                         .long("password")
                         .value_name("PASSWORD")
+                        .env("GEVULOT_PASSWORD")
                         .help("The password to compute the key with")
                         .value_hint(ValueHint::Other),
                 ),
@@ -400,7 +409,7 @@ fn setup_command_line_args() -> Result<Command, Box<dyn std::error::Error>> {
                         .value_hint(ValueHint::FilePath),
                 ),
         )
-        .subcommand(commands::sudo::get_command());
+        .subcommand(commands::sudo::get_command(&chain_args));
 
     #[cfg(target_os = "linux")]
     {


### PR DESCRIPTION
- Added missing password argument to chain args.
- Passed missing chain args to `sudo` commands.
- Added missing password env variable support to `compute-key`.