### PR TITLE
build: change `/workspace` to `/input` and `/ouput` dirs

### DIFF
--- a/src/builders/mod.rs
+++ b/src/builders/mod.rs
@@ -19,7 +19,7 @@ pub struct BuildOptions {
     pub nvidia_drivers: bool,
     pub kernel_modules: Vec<String>,
     pub mounts: Vec<String>,
-    pub no_gevulot_rt_config: bool,
+    pub no_gevulot_runtime: bool,
     pub no_default_mounts: bool,
     pub init: Option<String>,
     pub init_args: Option<String>,
@@ -101,7 +101,7 @@ impl std::fmt::Display for BuildOptions {
         writeln!(
             f,
             "| Gevulot runtime  | {:<42} |",
-            !self.no_gevulot_rt_config
+            !self.no_gevulot_runtime
         )?;
         writeln!(f, "| Default mounts   | {:<42} |", !self.no_default_mounts)?;
         writeln!(
@@ -166,7 +166,7 @@ impl TryFrom<&clap::ArgMatches> for BuildOptions {
                 .unwrap_or_default()
                 .cloned()
                 .collect::<Vec<_>>(),
-            no_gevulot_rt_config: matches.get_flag("no_gevulot_rt_config"),
+            no_gevulot_runtime: matches.get_flag("no_gevulot_runtime"),
             no_default_mounts: matches.get_flag("no_default_mounts"),
             init: matches.get_one::<String>("init").cloned(),
             init_args: matches.get_one::<String>("init_args").cloned(),

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -116,11 +116,12 @@ pub fn get_command() -> clap::Command {
                 .required(false),
         )
         .arg(
-            Arg::new("no_gevulot_rt_config")
-                .long("no-gevulot-rt-config")
-                .help("[MIA] Don't mount gevulot-rt-config. Only for debug purposes.")
-                .help("[MIA] Don't mount gevulot-rt-config. Only for debug purposes.\n\
+            Arg::new("no_gevulot_runtime")
+                .long("no-gevulot-runtime")
+                .help("[MIA] Don't install Gevulot runtime. Only for debug purposes.")
+                .help("[MIA] Don't install Gevulot runtime. Only for debug purposes.\n\
                        No following config will be provided to the VM. Only built-in one will be used.\n\
+                       No input/output context directories will be mounted.\n\
                        Note: Gevulot worker will provide runtime config through gevulot-rt-config.\n\
                        This means that images with this flag enabled cannot be executed on the network.\n\
                        This option can't be used together with --init or --init-args.")


### PR DESCRIPTION
Instead of creating `/workspace` directory inside VM, we will create `/mnt/input` and `/mnt/output` directories.

We do not create mounts for them in default runtime config (`/usr/lib/mia/config.yaml`). Mounts will be created by EVE through following runtime config. Otherwise it adds more conventions between worker nodes and VMs which makes harder to use custom VMs.