### PR TITLE
Bump up a version to v0.1.2 w/ a bugfix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gvltctl"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Gevulot Team"]
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ description = "Gevulot Control CLI"
 
 [dependencies]
 # TODO: change rev to tag when available
-gevulot-rs = { git = "https://github.com/gevulotnetwork/gevulot-rs.git", rev = "6695dcb0e7214a3ec07cdc2d83bbc4ff26ae2d38" }
+gevulot-rs = { git = "https://github.com/gevulotnetwork/gevulot-rs.git", rev = "28b6c9f39ebe8144cbd8eac746d7ada5b8646268" }
 
 bip32 = "0.5.1"
 clap = { version = "4", features = ["env", "cargo"] }


### PR DESCRIPTION
`gevulot-rs` had an index out of bounds bug in transaction response message check. This commit updates it to fixed version and bumps up our own version accordingly as well.