### PR TITLE
`sudo mkdir` the input/output directories

### DIFF
--- a/src/builders/skopeo_builder.rs
+++ b/src/builders/skopeo_builder.rs
@@ -470,7 +470,7 @@ impl SkopeoSyslinuxBuilder {
         let mnt = env::temp_dir().join("mnt").join("mnt");
         for path in [mnt.join("input"), mnt.join("output")] {
             if !path.exists() {
-                fs::create_dir_all(&path)
+                Self::run_command(&["mkdir", "-p", &format!("{}", path.display())], true)
                     .context(format!("Failed to create {} directory", path.display()))?;
             }
         }


### PR DESCRIPTION
If used base container image already has `/mnt` directory, it's often owned by `root:root` and with 755 permissions. Creation of subdirectories then fails due to lack of permissions, so perform this step w/ `sudo`.