### PR TITLE
Default VM kernel to 6.12

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -64,7 +64,7 @@ pub fn get_command() -> clap::Command {
                 .help("Linux kernel version to use (e.g., v6.10). Use 'latest' for the most recent version. \
                        This kernel will be compiled from source.")
                 .required(false)
-                .default_value("latest"),
+                .default_value("6.12"),
         )
         .arg(
             Arg::new("kernel_url")


### PR DESCRIPTION
6.12 is latest release and most probably next LTS version so it's good to pin into that one. Using `latest` as default is risky as end users might run into unexpected issues and it's difficult to debug when the used version is "unknown".