### PR TITLE
Add option to `gvltctl build` to specify MIA version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_format"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,6 +1029,37 @@ dependencies = [
 [[package]]
 name = "gevulot-rs"
 version = "0.1.0"
+source = "git+https://github.com/gevulotnetwork/gevulot-rs.git?rev=997bd6c5266a98a69253c58b4bd1a35e8d3ec7ae#997bd6c5266a98a69253c58b4bd1a35e8d3ec7ae"
+dependencies = [
+ "backon",
+ "bip32",
+ "const_format",
+ "cosmos-sdk-proto",
+ "cosmrs",
+ "derivative",
+ "derive_builder",
+ "hex",
+ "http 1.1.0",
+ "log",
+ "pretty_env_logger",
+ "prost 0.13.3",
+ "prost-build",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "semver",
+ "serde",
+ "serde_json",
+ "tendermint",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-buf-build",
+ "tonic-build",
+]
+
+[[package]]
+name = "gevulot-rs"
+version = "0.1.0"
 source = "git+https://github.com/gevulotnetwork/gevulot-rs.git?rev=f6657f57771b1c549a83cfe6fc822c3db687707e#f6657f57771b1c549a83cfe6fc822c3db687707e"
 dependencies = [
  "backon",
@@ -1074,7 +1125,7 @@ dependencies = [
  "clap_complete",
  "cosmrs",
  "env_logger 0.11.5",
- "gevulot-rs",
+ "gevulot-rs 0.1.0 (git+https://github.com/gevulotnetwork/gevulot-rs.git?rev=f6657f57771b1c549a83cfe6fc822c3db687707e)",
  "log",
  "mia-installer",
  "num_cpus",
@@ -1604,14 +1655,14 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mia-installer"
-version = "0.2.2"
-source = "git+https://github.com/gevulotnetwork/mia.git?tag=mia-installer-0.2.2#f9e39ba0c7c7b092ff798780fff353bfe5919693"
+version = "0.2.3"
+source = "git+https://github.com/gevulotnetwork/mia.git?tag=mia-installer-0.2.3#de5b5f12c8dc701fba2fd68a5b4e6e5469388ca0"
 dependencies = [
  "anyhow",
  "env_logger 0.11.5",
  "flate2",
  "fs_extra",
- "gevulot-rs",
+ "gevulot-rs 0.1.0 (git+https://github.com/gevulotnetwork/gevulot-rs.git?rev=997bd6c5266a98a69253c58b4bd1a35e8d3ec7ae)",
  "log",
  "octocrab",
  "reqwest",
@@ -3441,6 +3492,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1", features = ["full"] }
 toml = "0.8.19"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-mia-installer = { git = "https://github.com/gevulotnetwork/mia.git", tag = "mia-installer-0.2.2" }
+mia-installer = { git = "https://github.com/gevulotnetwork/mia.git", tag = "mia-installer-0.2.3" }
 
 anyhow = "1"
 log = "0.4.22"

--- a/src/builders/mod.rs
+++ b/src/builders/mod.rs
@@ -19,6 +19,7 @@ pub struct BuildOptions {
     pub nvidia_drivers: bool,
     pub kernel_modules: Vec<String>,
     pub mounts: Vec<String>,
+    pub mia_version: Option<String>,
     pub no_gevulot_runtime: bool,
     pub no_default_mounts: bool,
     pub init: Option<String>,
@@ -100,6 +101,13 @@ impl std::fmt::Display for BuildOptions {
         )?;
         writeln!(
             f,
+            "| MIA Version      | {:<42} |",
+            self.mia_version
+                .as_deref()
+                .unwrap_or("None")
+        )?;
+        writeln!(
+            f,
             "| Gevulot runtime  | {:<42} |",
             !self.no_gevulot_runtime
         )?;
@@ -166,6 +174,7 @@ impl TryFrom<&clap::ArgMatches> for BuildOptions {
                 .unwrap_or_default()
                 .cloned()
                 .collect::<Vec<_>>(),
+            mia_version: matches.get_one::<String>("mia_version").cloned(),
             no_gevulot_runtime: matches.get_flag("no_gevulot_runtime"),
             no_default_mounts: matches.get_flag("no_default_mounts"),
             init: matches.get_one::<String>("init").cloned(),

--- a/src/builders/skopeo_builder.rs
+++ b/src/builders/skopeo_builder.rs
@@ -122,6 +122,10 @@ impl ImageBuilder for SkopeoSyslinuxBuilder {
             if options.init.is_none() {
                 print(&format!("Installing MIA (Minimal Init Application)... "))?;
                 Self::install_mia(
+                    options
+                        .mia_version
+                        .as_ref()
+                        .context("MIA version is required")?,
                     &container_rt_config,
                     &kernel_modules,
                     &options.mounts,
@@ -577,6 +581,7 @@ impl SkopeoSyslinuxBuilder {
 
     /// Prepare MIA installation config and run installer.
     fn install_mia(
+        mia_version: &str,
         container_rt_config: &RuntimeConfig,
         kernel_modules: &Vec<String>,
         mounts: &Vec<String>,
@@ -642,12 +647,12 @@ impl SkopeoSyslinuxBuilder {
             mounts,
             default_mounts,
             kernel_modules: kernel_modules.clone(),
-            bootcmd: vec![],
             follow_config,
+            ..Default::default()
         };
 
         let mut install_config = mia_installer::InstallConfig::default();
-        install_config.mia_version = "latest".to_string();
+        install_config.mia_version = mia_version.to_string();
         install_config.mia_platform = "x86_64-unknown-linux-gnu".to_string();
         install_config.prefix = env::temp_dir().join("mnt");
         install_config.as_root = true;

--- a/src/builders/skopeo_builder.rs
+++ b/src/builders/skopeo_builder.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use log::debug;
-use gevulot_rs::runtime_config::{self, RuntimeConfig};
+use mia_installer::runtime_config::{self, RuntimeConfig};
 use oci_spec::image::{ImageConfiguration, ImageManifest};
 use std::io::{self, BufRead, BufReader, Write};
 use std::{env, fs, path::Path, process::Command};

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -116,6 +116,21 @@ pub fn get_command() -> clap::Command {
                 .required(false),
         )
         .arg(
+            Arg::new("mia_version")
+                .long("mia-version")
+                .value_name("STRING")
+                .help("[MIA] Install specified MIA version.")
+                .long_help("[MIA] Install specified MIA version.\n\
+                            Accepted format is from mia-installer. Examples:\n\
+                            - latest\n\
+                            - 0.1.0\n\
+                            - file:/path/to/mia/binary\n\
+                            This option can't be used together with --init or --init-args.")
+                .conflicts_with_all(["init", "init_args"])
+                .required(false)
+                .default_value("latest"),
+        )
+        .arg(
             Arg::new("no_gevulot_runtime")
                 .long("no-gevulot-runtime")
                 .help("[MIA] Don't install Gevulot runtime. Only for debug purposes.")

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -134,7 +134,7 @@ pub fn get_command() -> clap::Command {
             Arg::new("no_gevulot_runtime")
                 .long("no-gevulot-runtime")
                 .help("[MIA] Don't install Gevulot runtime. Only for debug purposes.")
-                .help("[MIA] Don't install Gevulot runtime. Only for debug purposes.\n\
+                .long_help("[MIA] Don't install Gevulot runtime. Only for debug purposes.\n\
                        No following config will be provided to the VM. Only built-in one will be used.\n\
                        No input/output context directories will be mounted.\n\
                        Note: Gevulot worker will provide runtime config through gevulot-rt-config.\n\


### PR DESCRIPTION
After this changes there will be option `--mia-version`. Examples of usage:

```shell
# this is default
gvltctl build --mia-version latest ...

# specific binary release from GitHub
gvltctl build --mia-version 0.3.0 ...

# locally compiled binary
gvltctl build --mia-version file:target/x86_64-unknown-linux-gnu/release/mia ...
```

Note that compatibility between `mia-installer` and `mia` is still not guaranteed. The only thing which is checked is that latest `mia-installer` tag can install latest MIA release.

Also: in this PR `mia-installer` version is bumped to allow us to use re-exported `gevulot_rs::runtime_config`.