### PR TITLE
0.1.3 pre-release changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,6 +73,8 @@ jobs:
       PCRE2_SYS_STATIC: 1
       # To ensure openssl is static linked
       OPENSSL_STATIC: 1
+      # Build static
+      RUSTFLAGS: "-C target-feature=+crt-static"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,9 +113,13 @@ jobs:
 
     - name: Install buf
       uses: bufbuild/buf-setup-action@v1
+      with:
+        github_token: ${{ github.token }}
 
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ github.token }}
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -190,6 +190,7 @@ jobs:
         mkdir -p "$ARCHIVE"
         cp "$BIN" "$ARCHIVE"/
         cp README.md "$ARCHIVE"/
+        cp LICENSE* "$ARCHIVE"/
 
     - name: Build archive (Windows)
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 # From https://github.com/BurntSushi/ripgrep/blob/master/.github/workflows/release.yml
 
-name: release
+name: Release
 
 on:
   workflow_dispatch:
@@ -16,6 +16,9 @@ jobs:
   create-release:
     name: create-release
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
 
@@ -30,7 +33,6 @@ jobs:
         run: |
           echo "version is: $VERSION"
       - name: Check that tag version and Cargo.toml version are the same
-        shell: bash
         run: |
           VERSION=${VERSION#v} # strip leading v if present only for the Cargo.toml check
           if ! grep -q "version = \"$VERSION\"" Cargo.toml; then
@@ -47,9 +49,12 @@ jobs:
       release_name: ${{ env.RELEASE_NAME }}
 
   build-release:
-    name: build-release
+    name: ${{ matrix.build }}
     needs: ['create-release']
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     env:
       # For some builds, we use cross to test on 32-bit and big-endian
       # systems.
@@ -72,25 +77,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - build: stable-x86
+        - build: ubuntu-x86
           os: ubuntu-latest
           rust: stable
           target: x86_64-unknown-linux-gnu
-          qemu: i386
-        - build: stable-aarch64
-          os: ubuntu-latest
+        # - build: ubuntu-aarch64
+        #   os: ubuntu-latest
+        #   rust: stable
+        #   target: aarch64-unknown-linux-gnu
+        #   strip: aarch64-linux-gnu-strip
+        - build: macos-x86
+          os: macos-latest
           rust: stable
-          target: aarch64-unknown-linux-gnu
-          strip: aarch64-linux-gnu-strip
-          qemu: qemu-aarch64
-        # - build: macos
-        #   os: macos-latest
-        #   rust: nightly
-        #   target: x86_64-apple-darwin
-        # - build: win-msvc
-        #   os: windows-latest
-        #   rust: nightly
-        #   target: x86_64-pc-windows-msvc
+          target: x86_64-apple-darwin
+        - build: macos-aarch64
+          os: macos-latest
+          rust: stable
+          target: aarch64-apple-darwin
 
     steps:
     - name: Checkout repository
@@ -98,7 +101,6 @@ jobs:
 
     - name: Install packages (Ubuntu)
       if: matrix.os == 'ubuntu-latest'
-      shell: bash
       run: |-
           sudo apt-get update
           sudo apt-get install -y openssl ca-certificates pkg-config cmake libssl-dev
@@ -110,11 +112,9 @@ jobs:
         brew install openssl pkg-config cmake
 
     - name: Install buf
-      if: matrix.os == 'ubuntu-latest'
       uses: bufbuild/buf-setup-action@v1
 
     - name: Install Protoc
-      if: matrix.os == 'ubuntu-latest'
       uses: arduino/setup-protoc@v3
 
     - name: Install Rust
@@ -124,8 +124,8 @@ jobs:
         target: ${{ matrix.target }}
 
     - name: Use Cross
-      if: matrix.os == 'ubuntu-latest' && matrix.target != ''
-      shell: bash
+      # Build without Cross for native target
+      if: matrix.os == 'ubuntu-latest' && matrix.target != 'x86_64-unknown-linux-gnu'
       run: |
         # In the past, new releases of 'cross' have broken CI. So for now, we
         # pin it. We also use their pre-compiled binary releases because cross
@@ -139,20 +139,15 @@ jobs:
         echo "CARGO=cross" >> $GITHUB_ENV
 
     - name: Set target variables
-      shell: bash
       run: |
         echo "TARGET_FLAGS=--target ${{ matrix.target }}" >> $GITHUB_ENV
-        echo "TARGET_DIR=./target/${{ matrix.target }}" >> $GITHUB_ENV
 
     - name: Show command used for Cargo
-      shell: bash
       run: |
         echo "cargo command is: ${{ env.CARGO }}"
         echo "target flag is: ${{ env.TARGET_FLAGS }}"
-        echo "target dir is: ${{ env.TARGET_DIR }}"
 
     - name: Build release binary
-      shell: bash
       run: |
         ${{ env.CARGO }} build --bin gvltctl --verbose --release ${{ env.TARGET_FLAGS }}
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
@@ -164,12 +159,10 @@ jobs:
 
     - name: Strip release binary (macos)
       if: matrix.os == 'macos-latest'
-      shell: bash
       run: strip "$BIN"
 
     - name: Strip release binary (cross)
       if: env.CARGO == 'cross' && matrix.strip != ''
-      shell: bash
       run: |
         docker run --rm -v \
           "$PWD/target:/target:Z" \
@@ -179,24 +172,20 @@ jobs:
 
     - name: Strip release binary (native strip)
       if: matrix.os != 'macos-latest' && matrix.strip == ''
-      shell: bash
       run: strip "$BIN"
 
     - name: Determine archive name
-      shell: bash
       run: |
         version="${{ needs.create-release.outputs.version }}"
         echo "ARCHIVE=gvltctl-${{ matrix.target }}" >> $GITHUB_ENV
 
     - name: Creating directory for archive
-      shell: bash
       run: |
         mkdir -p "$ARCHIVE"
         cp "$BIN" "$ARCHIVE"/
         cp README.md "$ARCHIVE"/
 
     - name: Build archive (Windows)
-      shell: bash
       if: matrix.os == 'windows-latest'
       run: |
         7z a "$ARCHIVE.zip" "$ARCHIVE"
@@ -205,7 +194,6 @@ jobs:
         echo "ASSET_SUM=$ARCHIVE.zip.sha256" >> $GITHUB_ENV
 
     - name: Build archive (Unix)
-      shell: bash
       if: matrix.os != 'windows-latest'
       run: |
         tar czf "$ARCHIVE.tar.gz" "$ARCHIVE"
@@ -216,7 +204,6 @@ jobs:
     - name: Upload release archive
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      shell: bash
       run: |
         release_name="v${{ needs.create-release.outputs.version }}"
         gh release upload "$release_name" ${{ env.ASSET }} ${{ env.ASSET_SUM }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -155,7 +155,7 @@ jobs:
 
     - name: Build release binary
       run: |
-        ${{ env.CARGO }} build --bin gvltctl --verbose --release ${{ env.TARGET_FLAGS }}
+        ${{ env.CARGO }} build --bin gvltctl --verbose --release --features openssl-vendored ${{ env.TARGET_FLAGS }}
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
           bin="target/${{ matrix.target }}/release/gvltctl.exe"
         else

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,6 +103,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y openssl ca-certificates pkg-config cmake libssl-dev
 
+    - name: Install packages (MacOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew update
+        brew install openssl pkg-config cmake
+
     - name: Install buf
       if: matrix.os == 'ubuntu-latest'
       uses: bufbuild/buf-setup-action@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -209,5 +209,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        release_name="v${{ needs.create-release.outputs.version }}"
+        release_name="${{ needs.create-release.outputs.version }}"
         gh release upload "$release_name" ${{ env.ASSET }} ${{ env.ASSET_SUM }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "gvltctl"
-version = "0.1.2"
+version = "0.1.3-pre"
 dependencies = [
  "anyhow",
  "bip32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,6 +1058,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "gevulot-rs"
+version = "0.1.3-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1977ff04d85b4193740d7912da483af0b87446b3c8863b9912a78a985d85f09f"
+dependencies = [
+ "backon",
+ "bip32",
+ "const_format",
+ "cosmos-sdk-proto",
+ "cosmrs",
+ "derivative",
+ "derive_builder",
+ "hex",
+ "http 1.1.0",
+ "log",
+ "pretty_env_logger",
+ "prost 0.13.3",
+ "prost-build",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "semver",
+ "serde",
+ "serde_json",
+ "tendermint",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-buf-build",
+ "tonic-build",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,7 +1128,7 @@ dependencies = [
  "clap_complete",
  "cosmrs",
  "env_logger 0.11.5",
- "gevulot-rs",
+ "gevulot-rs 0.1.3-pre.2",
  "log",
  "mia-installer",
  "num_cpus",
@@ -1633,7 +1665,7 @@ dependencies = [
  "env_logger 0.11.5",
  "flate2",
  "fs_extra",
- "gevulot-rs",
+ "gevulot-rs 0.1.0",
  "log",
  "octocrab",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,37 +1028,6 @@ dependencies = [
 
 [[package]]
 name = "gevulot-rs"
-version = "0.1.0"
-source = "git+https://github.com/gevulotnetwork/gevulot-rs.git?rev=e972c7c73a88182d22121a995f01abed04dff106#e972c7c73a88182d22121a995f01abed04dff106"
-dependencies = [
- "backon",
- "bip32",
- "const_format",
- "cosmos-sdk-proto",
- "cosmrs",
- "derivative",
- "derive_builder",
- "hex",
- "http 1.1.0",
- "log",
- "pretty_env_logger",
- "prost 0.13.3",
- "prost-build",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "semver",
- "serde",
- "serde_json",
- "tendermint",
- "thiserror",
- "tokio",
- "tonic",
- "tonic-buf-build",
- "tonic-build",
-]
-
-[[package]]
-name = "gevulot-rs"
 version = "0.1.3-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1977ff04d85b4193740d7912da483af0b87446b3c8863b9912a78a985d85f09f"
@@ -1128,7 +1097,7 @@ dependencies = [
  "clap_complete",
  "cosmrs",
  "env_logger 0.11.5",
- "gevulot-rs 0.1.3-pre.2",
+ "gevulot-rs",
  "log",
  "mia-installer",
  "num_cpus",
@@ -1658,14 +1627,14 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mia-installer"
-version = "0.2.3"
-source = "git+https://github.com/gevulotnetwork/mia.git?tag=mia-installer-0.2.4#07ac1b6dbba8969cc09b54a6b68b02fb4f0afbbd"
+version = "0.2.5"
+source = "git+https://github.com/gevulotnetwork/mia.git?tag=mia-installer-0.2.5#2733a55e3290db99daaa5def9f4e77215df6c2fd"
 dependencies = [
  "anyhow",
  "env_logger 0.11.5",
  "flate2",
  "fs_extra",
- "gevulot-rs 0.1.0",
+ "gevulot-rs",
  "log",
  "octocrab",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,7 @@ dependencies = [
  "mia-installer",
  "num_cpus",
  "oci-spec",
+ "openssl",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
@@ -1850,6 +1851,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.4.1+3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +1867,7 @@ checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "gevulot-rs"
-version = "0.1.3-pre.2"
+version = "0.1.3-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1977ff04d85b4193740d7912da483af0b87446b3c8863b9912a78a985d85f09f"
+checksum = "79c50801b8a96e1e3159339cb2b8bd679507d27ba806b17c9f3fe9c1dcd44178"
 dependencies = [
  "backon",
  "bip32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,6 @@ description = "Gevulot Control CLI"
 
 [dependencies]
 # TODO: change rev to tag when available
-# NOTE: this revision is aligned with `mia-installer` dependency.
-# Be careful changing it.
 gevulot-rs = { git = "https://github.com/gevulotnetwork/gevulot-rs.git", rev = "e972c7c73a88182d22121a995f01abed04dff106" }
 
 bip32 = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gvltctl"
-version = "0.1.2"
+version = "0.1.3-pre"
 edition = "2021"
 authors = ["Gevulot Team"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1", features = ["full"] }
 toml = "0.8.19"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-mia-installer = { git = "https://github.com/gevulotnetwork/mia.git", tag = "mia-installer-0.2.4"}
+mia-installer = { git = "https://github.com/gevulotnetwork/mia.git", tag = "mia-installer-0.2.5"}
 
 anyhow = "1"
 log = "0.4.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ repository = "https://github.com/gevulotnetwork/gvltctl"
 description = "Gevulot Control CLI"
 
 [dependencies]
-# TODO: change rev to tag when available
-gevulot-rs = { git = "https://github.com/gevulotnetwork/gevulot-rs.git", rev = "e972c7c73a88182d22121a995f01abed04dff106" }
+gevulot-rs = "0.1.3-pre.2"
 
 bip32 = "0.5.1"
 clap = { version = "4", features = ["env", "cargo"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/gevulotnetwork/gvltctl"
 description = "Gevulot Control CLI"
 
 [dependencies]
-gevulot-rs = "0.1.3-pre.2"
+gevulot-rs = "0.1.3-pre.3"
 
 bip32 = "0.5.1"
 clap = { version = "4", features = ["env", "cargo"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,11 @@ serde_json = "1"
 serde_yaml = "0.9.34"
 tokio = { version = "1", features = ["full"] }
 toml = "0.8.19"
+openssl = { version = "*", optional = true }
+
+[features]
+# This feature should be enabled when building static executable
+openssl-vendored = ["openssl/vendored"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 mia-installer = { git = "https://github.com/gevulotnetwork/mia.git", tag = "mia-installer-0.2.5"}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# gvltctl
+# Gevulot Control CLI
+
+This tool is used to interact with Gevulot Network.
+
+## Installation
+
+### Pre-built releases
+
+You can download pre-built release binaries from [releases](https://github.com/gevulotnetwork/gvltctl/releases):
+
+Supported platforms:
+
+- `x86_64-unknown-linux-gnu`
+- `x86_64-apple-darwin`
+- `aarch64-apple-darwin`
+
+#### Installation of pre-built release
+
+1. Download archive
+
+    ```shell
+    curl -fLO https://github.com/gevulotnetwork/gvltctl/releases/download/${VERSION}/gvltctl-${PLATFORM}.tar.gz
+    ```
+
+2. (Optional) Verify checksum
+
+    ```shell
+    curl -fLO https://github.com/gevulotnetwork/gvltctl/releases/download/${VERSION}/gvltctl-${PLATFORM}.tar.gz.sha256
+    sha256sum -c gvltctl-${PLATFORM}.tar.gz.sha256
+    ```
+
+3. Install the binary
+
+    ```shell
+      tar xf gvltctl-${PLATFORM}.tar.gz
+      cp gvltctl-${PLATFORM}/gvltctl $HOME/.local/bin
+    ```
+
+### Compiling from sources
+
+```shell
+cargo install --git https://github.com/gevulotnetwork/gvltctl.git --tag $VERSION
+```
+
+## Usage
+
+```shell
+$ gvltctl --help
+Gevulot Control CLI
+
+Usage: gvltctl <COMMAND>
+
+Commands:
+  worker               Commands related to workers
+  pin                  Commands related to pins
+  task                 Commands related to tasks
+  workflow             Commands related to workflows
+  keygen               Generate a new key
+  compute-key          Compute a key
+  send                 Send tokens to a receiver on the Gevulot network
+  account-info         Get the balance of the given account
+  generate-completion  Generate shell completion scripts
+  sudo                 Perform administrative operations with sudo privileges
+  build                Build a VM image from a container, rootfs directory, or Containerfile
+  help                 Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+```


### PR DESCRIPTION
Changes:

- Updated versions of `gevulot-rs` and `mia-installer`
- Added feature `openssl-vendored`
- Refactored release workflow:
  - Don't use Cross when building for x86_64 Linux
  - Refine releasing targets list
  - Specify default shell for the job
  - Link release binary statically

After these changes we should be able to automatically release pre-built binaries for:

- `x86_64-unknown-linux-gnu`
- `x86_64-apple-darwin`
- `aarch64-apple-darwin`

whenever a new tag of format `v1.2.3` is pushed.

Also this release workflow can be triggered manually for any ref (tag).