### PR TITLE
update gevulot-rs and bump crate version 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,6 +1058,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "gevulot-rs"
+version = "0.1.3-pre.2"
+source = "git+https://github.com/gevulotnetwork/gevulot-rs.git?tag=v0.1.3-pre.2#e91a1100d7ebde0433b72db43da63bbe5cf19a1a"
+dependencies = [
+ "backon",
+ "bip32",
+ "const_format",
+ "cosmos-sdk-proto",
+ "cosmrs",
+ "derivative",
+ "derive_builder",
+ "hex",
+ "http 1.1.0",
+ "log",
+ "pretty_env_logger",
+ "prost 0.13.3",
+ "prost-build",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "semver",
+ "serde",
+ "serde_json",
+ "tendermint",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-buf-build",
+ "tonic-build",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "gvltctl"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "bip32",
@@ -1096,11 +1127,12 @@ dependencies = [
  "clap_complete",
  "cosmrs",
  "env_logger 0.11.5",
- "gevulot-rs",
+ "gevulot-rs 0.1.3-pre.2",
  "log",
  "mia-installer",
  "num_cpus",
  "oci-spec",
+ "openssl",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
@@ -1633,7 +1665,7 @@ dependencies = [
  "env_logger 0.11.5",
  "flate2",
  "fs_extra",
- "gevulot-rs",
+ "gevulot-rs 0.1.0",
  "log",
  "octocrab",
  "reqwest",
@@ -1849,6 +1881,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.3.2+3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,6 +1897,7 @@ checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gvltctl"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Gevulot Team"]
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ description = "Gevulot Control CLI"
 # TODO: change rev to tag when available
 # NOTE: this revision is aligned with `mia-installer` dependency.
 # Be careful changing it.
-gevulot-rs = { git = "https://github.com/gevulotnetwork/gevulot-rs.git", rev = "e972c7c73a88182d22121a995f01abed04dff106" }
+gevulot-rs = { git = "https://github.com/gevulotnetwork/gevulot-rs.git", tag = "v0.1.3-pre.2" }
 
 bip32 = "0.5.1"
 clap = { version = "4", features = ["env", "cargo"] }
@@ -34,3 +34,7 @@ num_cpus = "1.16.0"
 oci-spec = "0.7.0"
 tempdir = "0.3.7"
 thiserror = "1"
+
+[dependencies.openssl]
+version = "*"
+features = ["vendored"]


### PR DESCRIPTION
If we get this merged, we can tag v0.1.3 and call it a release.