### PR TITLE
Extend version command for gvltctl

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,2 @@
+target/
+.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.64",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.7",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,7 +552,7 @@ dependencies = [
  "subtle-encoding",
  "tendermint",
  "tendermint-rpc",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
 ]
 
@@ -1059,7 +1105,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tendermint",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tonic",
  "tonic-buf-build",
@@ -1114,6 +1160,7 @@ version = "0.1.3-pre"
 dependencies = [
  "anyhow",
  "bip32",
+ "cargo_metadata 0.19.1",
  "clap 4.5.20",
  "clap_complete",
  "cosmrs",
@@ -1130,7 +1177,7 @@ dependencies = [
  "serde_yaml",
  "shadow-rs",
  "tempdir",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "toml",
 ]
@@ -1834,7 +1881,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2662,6 +2709,9 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -2789,9 +2839,11 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd2f59f8b166e94269530e0f47323c8b2a5b2d82ef90363cc7ce1e517e063f78"
 dependencies = [
+ "cargo_metadata 0.18.1",
  "const_format",
  "git2",
  "is_debug",
+ "serde_json",
  "time",
  "tzdb",
 ]
@@ -2829,7 +2881,7 @@ checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.64",
  "time",
 ]
 
@@ -3143,7 +3195,7 @@ dependencies = [
  "tendermint",
  "tendermint-config",
  "tendermint-proto",
- "thiserror",
+ "thiserror 1.0.64",
  "time",
  "tokio",
  "tracing",
@@ -3176,7 +3228,16 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.64",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93605438cbd668185516ab499d589afb7ee1859ea3d5fc8f6b0755e1c7443767"
+dependencies = [
+ "thiserror-impl 2.0.7",
 ]
 
 [[package]]
@@ -3184,6 +3245,17 @@ name = "thiserror-impl"
 version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -141,7 +141,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -348,6 +348,8 @@ version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -432,6 +434,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_fn"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
 name = "const_format"
@@ -576,7 +584,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -587,7 +595,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -638,7 +646,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -648,7 +656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -957,7 +965,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1023,7 +1031,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1063,6 +1071,19 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "gloo-timers"
@@ -1107,6 +1128,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shadow-rs",
  "tempdir",
  "thiserror",
  "tokio",
@@ -1504,6 +1526,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_debug"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ea828c9d6638a5bd3d8b14e37502b4d56cae910ccf8a5b7f51c7a0eb1d0508"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1560,15 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1582,6 +1619,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1639,18 @@ dependencies = [
  "bitflags 2.6.0",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1743,6 +1804,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,7 +1911,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1981,7 +2051,7 @@ checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2044,7 +2114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2090,14 +2160,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -2139,7 +2209,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types",
  "regex",
- "syn 2.0.79",
+ "syn 2.0.90",
  "tempfile",
 ]
 
@@ -2153,7 +2223,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2166,7 +2236,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2619,7 +2689,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2652,7 +2722,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2711,6 +2781,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "shadow-rs"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd2f59f8b166e94269530e0f47323c8b2a5b2d82ef90363cc7ce1e517e063f78"
+dependencies = [
+ "const_format",
+ "git2",
+ "is_debug",
+ "time",
+ "tzdb",
 ]
 
 [[package]]
@@ -2783,7 +2866,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2864,7 +2947,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2901,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3104,7 +3187,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3115,7 +3198,9 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -3179,7 +3264,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3328,7 +3413,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3419,7 +3504,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3442,6 +3527,35 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "tz-rs"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+dependencies = [
+ "const_fn",
+]
+
+[[package]]
+name = "tzdb"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b580f6b365fa89f5767cdb619a55d534d04a4e14c2d7e5b9a31e94598687fb1"
+dependencies = [
+ "iana-time-zone",
+ "tz-rs",
+ "tzdb_data",
+]
+
+[[package]]
+name = "tzdb_data"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654c1ec546942ce0594e8d220e6b8e3899e0a0a8fe70ddd54d32a376dfefe3f8"
+dependencies = [
+ "tz-rs",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -3587,7 +3701,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
@@ -3621,7 +3735,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3878,7 +3992,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3898,5 +4012,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.90",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,13 @@ description = "Gevulot Control CLI"
 gevulot-rs = "0.1.3-pre.3"
 
 bip32 = "0.5.1"
+cargo_metadata = "0.19"
 clap = { version = "4", features = ["env", "cargo", "string"] }
 clap_complete = "4.5.13"
 cosmrs = "0.20"
 env_logger = "0.11.5"
 rand_core = "0.6.4"
-shadow-rs = "0.36"
+shadow-rs = { version = "0.36", features = ["metadata"] }
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.9.34"
@@ -25,7 +26,7 @@ toml = "0.8.19"
 openssl = { version = "*", optional = true }
 
 [build-dependencies]
-shadow-rs = "0.36"
+shadow-rs = { version = "0.36", features = ["metadata"] }
 
 [features]
 # This feature should be enabled when building static executable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,21 @@ description = "Gevulot Control CLI"
 gevulot-rs = "0.1.3-pre.3"
 
 bip32 = "0.5.1"
-clap = { version = "4", features = ["env", "cargo"] }
+clap = { version = "4", features = ["env", "cargo", "string"] }
 clap_complete = "4.5.13"
 cosmrs = "0.20"
 env_logger = "0.11.5"
 rand_core = "0.6.4"
+shadow-rs = "0.36"
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.9.34"
 tokio = { version = "1", features = ["full"] }
 toml = "0.8.19"
 openssl = { version = "*", optional = true }
+
+[build-dependencies]
+shadow-rs = "0.36"
 
 [features]
 # This feature should be enabled when building static executable

--- a/Containerfile
+++ b/Containerfile
@@ -20,9 +20,13 @@ RUN cargo build --release
 
 # Copy the source code and build script
 COPY src ./src
+COPY build.rs .
 
 # Build the project
 RUN cargo build --release && cp target/release/gvltctl /gvltctl-bin
+
+# FIXME: gvltctl --version here will always report empty build info,
+# because there is no .git/ in the container.
 
 # Use a minimal base image for the final stage
 FROM debian:bullseye-slim

--- a/Containerfile
+++ b/Containerfile
@@ -19,8 +19,7 @@ COPY Cargo.lock .
 RUN cargo build --release
 
 # Copy the source code and build script
-COPY src ./src
-COPY build.rs .
+ADD . .
 
 # Build the project
 RUN cargo build --release && cp target/release/gvltctl /gvltctl-bin

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
 fn main() -> shadow_rs::SdResult<()> {
     let mut deny = std::collections::BTreeSet::new();
     deny.insert(shadow_rs::CARGO_TREE);
-    deny.insert(shadow_rs::CARGO_METADATA);
     shadow_rs::new_deny(deny)
 }

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 fn main() -> shadow_rs::SdResult<()> {
+    println!("cargo:rerun-if-changed=./");
     let mut deny = std::collections::BTreeSet::new();
     deny.insert(shadow_rs::CARGO_TREE);
     shadow_rs::new_deny(deny)

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+fn main() -> shadow_rs::SdResult<()> {
+    let mut deny = std::collections::BTreeSet::new();
+    deny.insert(shadow_rs::CARGO_TREE);
+    deny.insert(shadow_rs::CARGO_METADATA);
+    shadow_rs::new_deny(deny)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,8 @@ mod commands;
 use commands::build::*;
 use commands::{pins::*, sudo::*, tasks::*, workers::*};
 
+shadow_rs::shadow!(build_info);
+
 /// Main entry point for the Gevulot Control CLI application.
 ///
 /// This function sets up the command-line interface, parses arguments,
@@ -141,6 +143,25 @@ fn setup_command_line_args() -> Result<Command, Box<dyn std::error::Error>> {
 
     #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
     let mut command = clap::command!()
+        .long_version(format!(
+            "{} ({})\nplatform: {}",
+            build_info::PKG_VERSION,
+            if build_info::GIT_CLEAN {
+                format!(
+                    "{} {}",
+                    if build_info::TAG.is_empty() {
+                        build_info::SHORT_COMMIT
+                    } else {
+                        build_info::TAG
+                    },
+                    // Strip commit time and leave only date
+                    build_info::COMMIT_DATE.split(' ').collect::<Vec<_>>()[0],
+                )
+            } else {
+                format!("{}-dirty", build_info::SHORT_COMMIT)
+            },
+            build_info::BUILD_TARGET,
+        ))
         .subcommand_required(true)
         // Worker subcommand
         .subcommand(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use bip32::{Mnemonic, Prefix, XPrv};
+use cargo_metadata::Metadata;
 use clap::ArgAction;
 use clap::{value_parser, Arg, Command, ValueHint};
 use clap_complete::{generate, Shell};
@@ -7,7 +8,7 @@ use gevulot_rs::gevulot_client::GevulotClientBuilder;
 use gevulot_rs::GevulotClient;
 use rand_core::OsRng;
 use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{self, Read, Write};
 
@@ -84,6 +85,68 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Get gevulot-rs dependency version from cargo metadata.
+fn get_gevulot_rs_version(metadata: &Metadata) -> Option<String> {
+    const GEVULOT_RS_NAME: &str = "gevulot-rs";
+    let gvltctl = metadata.root_package()?;
+    let gevulot_rs_dep = gvltctl
+        .dependencies
+        .iter()
+        .find(|dep| &dep.name == GEVULOT_RS_NAME)?;
+
+    if let Some(path) = gevulot_rs_dep.path.as_ref() {
+        Some(format!(
+            "{} ({})",
+            metadata
+                .packages
+                .iter()
+                .find(|package| {
+                    &package.name == GEVULOT_RS_NAME && package.id.repr.starts_with("path")
+                })?
+                .version,
+            path.as_str()
+        ))
+    } else if gevulot_rs_dep
+        .source
+        .as_ref()
+        .is_some_and(|src| src.starts_with("git"))
+    {
+        metadata.packages.iter().find_map(|package| {
+            if &package.name == GEVULOT_RS_NAME {
+                package
+                    .id
+                    .repr
+                    .strip_prefix("git+")?
+                    .split('#')
+                    .collect::<Vec<_>>()
+                    .get(0)
+                    .map(|id| format!("{} ({})", package.version, id))
+            } else {
+                None
+            }
+        })
+    } else if gevulot_rs_dep
+        .source
+        .as_ref()
+        .is_some_and(|src| src.starts_with("registry"))
+    {
+        metadata.packages.iter().find_map(|package| {
+            if &package.name == GEVULOT_RS_NAME
+                && package
+                    .source
+                    .as_ref()
+                    .is_some_and(cargo_metadata::Source::is_crates_io)
+            {
+                Some(package.version.to_string())
+            } else {
+                None
+            }
+        })
+    } else {
+        return None;
+    }
+}
+
 /// Parses command-line arguments and returns the matches.
 ///
 /// This function sets up the entire command-line interface structure,
@@ -141,10 +204,20 @@ fn setup_command_line_args() -> Result<Command, Box<dyn std::error::Error>> {
             .action(ArgAction::Set),
     ];
 
+    let gevulot_rs_version =
+        serde_json::from_slice::<serde_json::Value>(&build_info::CARGO_METADATA)
+            .ok()
+            .map(Metadata::deserialize)
+            .map(Result::ok)
+            .flatten()
+            .as_ref()
+            .map(get_gevulot_rs_version)
+            .flatten();
+
     #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
     let mut command = clap::command!()
         .long_version(format!(
-            "{} ({})\nplatform: {}",
+            "{} ({})\ngevulot-rs {}\nplatform: {}",
             build_info::PKG_VERSION,
             if build_info::GIT_CLEAN {
                 format!(
@@ -160,6 +233,7 @@ fn setup_command_line_args() -> Result<Command, Box<dyn std::error::Error>> {
             } else {
                 format!("{}-dirty", build_info::SHORT_COMMIT)
             },
+            gevulot_rs_version.unwrap_or_else(|| "unknown".to_string()),
             build_info::BUILD_TARGET,
         ))
         .subcommand_required(true)


### PR DESCRIPTION
`gvltctl --version` will now include:

- commit info (short commit hash or tag and date)
- platform info
- `gevulot-rs` version

Examples:

```
gvltctl 0.1.3-pre (v0.1.3-pre 2024-12-12)
gevulot-rs 0.1.3-pre.3
platform: x86_64-unknown-linux-gnu
```

```
gvltctl 0.1.3-pre (ae0f1431 2024-12-14)
gevulot-rs 0.1.3-pre.3
platform: x86_64-unknown-linux-gnu
```

```
gvltctl 0.1.3-pre (47514d00-dirty)
gevulot-rs 0.1.3-pre.3 (https://github.com/gevulotnetwork/gevulot-rs?rev=f6ba24f22606e76f0fed89c773a8907fa8f72cfd)
platform: x86_64-unknown-linux-gnu
```

```
gvltctl 0.1.3-pre (47514d00-dirty)
gevulot-rs 0.1.3-pre.3 (/home/alea/gevulot/gevulot-rs)
platform: x86_64-unknown-linux-gnu
```

Doesn't work in our current container, because we don't copy `.git/` there.

## Important notes

- This may not work properly, when re-building after changing something in the project. That happens because `shadow-rs` doesn't re-run build script every time anything changes in the directory for efficiency reasons.
- Calculation of `gevulot-rs` version is a bit cumbersome and not very efficient.

If we find these points concerning we can eliminate all `gevulot-rs`-version related things (commit b99feedf883ae4af764a3ee4a9c442f9a85a1436) from this PR.