### PR TITLE
Fix conflicting CLI option short name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,7 @@ fn setup_command_line_args() -> Result<Command, Box<dyn std::error::Error>> {
             .value_hint(ValueHint::Other)
             .action(ArgAction::Set),
         Arg::new("password")
-            .short('n')
+            .short('p')
             .long("password")
             .value_name("PASSWORD")
             .env("GEVULOT_PASSWORD")


### PR DESCRIPTION
`-n` was used for both mnemonic and password options. It was leading to a runtime panic, which appeared only in debug build:

```
thread 'main' panicked at /home/alea/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.20/src/builder/debug_asserts.rs:112:17:
Command get: Short option names must be unique for each argument, but '-n' is in use by both 'mnemonic' and 'password'
```