### PR TITLE
Refactor CLI implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -461,6 +462,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9646e2e245bf62f45d39a0f3f36f1171ad1ea0d6967fd114bca72cb02a8fcdfb"
 dependencies = [
  "clap 4.5.20",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1171,6 +1184,7 @@ dependencies = [
  "num_cpus",
  "oci-spec",
  "openssl",
+ "patharg",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
@@ -2017,6 +2031,16 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "patharg"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ada2bee7a186eb0d859bb985e47991d4c5b6887c95fc28c44ebc0e7d52b526a"
+dependencies = [
+ "cfg-if",
+ "either",
+]
 
 [[package]]
 name = "pbkdf2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ gevulot-rs = "0.1.3"
 
 bip32 = "0.5.1"
 cargo_metadata = "0.19"
-clap = { version = "4", features = ["env", "cargo", "string"] }
+clap = { version = "4", features = ["derive", "env", "string"] }
 clap_complete = "4.5.13"
 cosmrs = "0.20"
 env_logger = "0.11.5"
+patharg = "0.4"
 rand_core = "0.6.4"
 shadow-rs = { version = "0.36", features = ["metadata"] }
 serde = "1"

--- a/src/builders/mod.rs
+++ b/src/builders/mod.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
 
+use crate::build::BuildArgs;
+
 pub mod nvidia;
 pub mod skopeo_builder;
 
@@ -102,15 +104,9 @@ impl std::fmt::Display for BuildOptions {
         writeln!(
             f,
             "| MIA Version      | {:<42} |",
-            self.mia_version
-                .as_deref()
-                .unwrap_or("None")
+            self.mia_version.as_deref().unwrap_or("None")
         )?;
-        writeln!(
-            f,
-            "| Gevulot runtime  | {:<42} |",
-            !self.no_gevulot_runtime
-        )?;
+        writeln!(f, "| Gevulot runtime  | {:<42} |", !self.no_gevulot_runtime)?;
         writeln!(f, "| Default mounts   | {:<42} |", !self.no_default_mounts)?;
         writeln!(
             f,
@@ -145,48 +141,40 @@ impl std::fmt::Display for BuildOptions {
     }
 }
 
-impl TryFrom<&clap::ArgMatches> for BuildOptions {
-    type Error = &'static str;
-
-    fn try_from(matches: &clap::ArgMatches) -> Result<Self, Self::Error> {
-        Ok(BuildOptions {
-            container_source: matches.get_one::<String>("container_source").cloned(),
-            rootfs_dir: matches.get_one::<String>("rootfs_dir").cloned(),
-            containerfile: matches.get_one::<String>("containerfile").cloned(),
-            image_size: matches
-                .get_one::<String>("image_size")
-                .ok_or("need image size")?
-                .to_string(),
-            kernel_version: matches
-                .get_one::<String>("kernel_version")
-                .ok_or("need kernel version")?
-                .to_string(),
-            kernel_url: matches.get_one::<String>("kernel_url").cloned(),
-            kernel_file: matches.get_one::<String>("kernel_file").cloned(),
-            nvidia_drivers: matches.get_flag("nvidia_drivers"),
-            kernel_modules: matches
-                .get_many::<String>("kernel_module")
-                .unwrap_or_default()
-                .cloned()
-                .collect::<Vec<_>>(),
-            mounts: matches
-                .get_many::<String>("mount")
-                .unwrap_or_default()
-                .cloned()
-                .collect::<Vec<_>>(),
-            mia_version: matches.get_one::<String>("mia_version").cloned(),
-            no_gevulot_runtime: matches.get_flag("no_gevulot_runtime"),
-            no_default_mounts: matches.get_flag("no_default_mounts"),
-            init: matches.get_one::<String>("init").cloned(),
-            init_args: matches.get_one::<String>("init_args").cloned(),
-            rw_root: matches.get_flag("rw_root"),
-            mbr_file: matches.get_one::<String>("mbr_file").cloned(),
-            output_file: matches
-                .get_one::<String>("output_file")
-                .unwrap()
-                .to_string(),
-            force: matches.get_flag("force"),
-            quiet: matches.get_flag("quiet"),
-        })
+impl From<&BuildArgs> for BuildOptions {
+    fn from(args: &BuildArgs) -> Self {
+        BuildOptions {
+            container_source: args.image.container.clone(),
+            rootfs_dir: args
+                .image
+                .rootfs_dir
+                .as_ref()
+                .map(|path| path.to_string_lossy().to_string()),
+            containerfile: args
+                .image
+                .containerfile
+                .as_ref()
+                .map(|path| path.to_string_lossy().to_string()),
+            image_size: args.image_size.clone(),
+            kernel_version: args.kernel_version.clone(),
+            kernel_url: Some(args.kernel_url.clone()),
+            kernel_file: args.kernel_file.clone(),
+            nvidia_drivers: args.nvidia_drivers,
+            kernel_modules: args.kernel_modules.clone(),
+            mounts: args.mounts.clone(),
+            mia_version: Some(args.mia_version.clone()),
+            no_gevulot_runtime: args.no_gevulot_runtime,
+            no_default_mounts: args.no_default_mounts,
+            init: args.init.clone(),
+            init_args: args.init_args.clone(),
+            rw_root: args.rw_root,
+            mbr_file: args
+                .mbr_file
+                .as_ref()
+                .map(|path| path.to_string_lossy().to_string()),
+            output_file: args.output_file.to_string_lossy().to_string(),
+            force: args.force,
+            quiet: args.quiet,
+        }
     }
 }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,226 +1,210 @@
 use crate::builders::skopeo_builder::SkopeoSyslinuxBuilder;
 use crate::builders::{BuildOptions, ImageBuilder};
-use anyhow::Result;
-use clap::{Arg, ArgGroup, ValueHint};
+use crate::OutputFormat;
+use clap::ValueHint;
+use std::path::PathBuf;
 
-pub fn get_command() -> clap::Command {
-    clap::Command::new("build")
-        .about("Build a VM image from a container, rootfs directory, or Containerfile")
-        .arg(
-            Arg::new("container_source")
-                .short('c')
-                .long("container")
-                .value_name("IMAGE")
-                .help("Container image to use as the source. Supports various transport methods:\n\
-                       - docker: Docker registry (e.g., docker://docker.io/debian:latest)\n\
-                       - containers-storage: Local container storage (e.g., containers-storage:localhost/myimage:latest)\n\
-                       - dir: Local directory (e.g., dir:/path/to/image)\n\
-                       - oci: OCI image layout (e.g., oci:/path/to/layout)\n\
-                       - docker-archive: Docker archive (e.g., docker-archive:/path/to/archive.tar)\n\
-                       Examples:\n\
-                       - docker://docker.io/ubuntu:20.04\n\
-                       - containers-storage:localhost/custom-image:latest")
-                .required(false)
-        )
-        .arg(
-            Arg::new("rootfs_dir")
-                .long("rootfs-dir")
-                .value_name("DIR")
-                .value_hint(ValueHint::FilePath)
-                .help("Directory containing the root filesystem to use. This should be a fully \
-                       prepared root filesystem, typically extracted from a container or created manually.")
-                .required(false)
-        )
-        .arg(
-            Arg::new("containerfile")
-                .long("containerfile")
-                .short('f')
-                .value_name("FILE")
-                .value_hint(ValueHint::FilePath)
-                .help("Path to a Containerfile (Dockerfile) to build the container image. \
-                       The file will be used to build a new image which will then be used as the source.")
-                .required(false)
-        )
-        .group(
-            ArgGroup::new("image")
-                .args(["container_source", "rootfs_dir", "containerfile"])
-                .multiple(false)
-                .required(true)
-        )
-        .arg(
-            Arg::new("image_size")
-                .short('s')
-                .long("size")
-                .value_name("SIZE")
-                .help("Size of the disk image (e.g., 10G, 1024M). This determines the total capacity of the VM's virtual disk.")
-                .required(false)
-                .default_value("10G"),
-        )
-        .arg(
-            Arg::new("kernel_version")
-                .short('k')
-                .long("kernel")
-                .value_name("VERSION")
-                .help("Linux kernel version to use (e.g., v6.10). Use 'latest' for the most recent version. \
-                       This kernel will be compiled from source.")
-                .required(false)
-                .default_value("v6.12"),
-        )
-        .arg(
-            Arg::new("kernel_url")
-                .long("kernel-url")
-                .value_name("URL")
-                .value_hint(ValueHint::Url)
-                .help("URL of the Linux kernel repository to clone. Change this if you want to use a fork or mirror.")
-                .required(false)
-                .default_value("https://github.com/torvalds/linux.git"),
-        )
-        .arg(
-            Arg::new("kernel_file")
-                .long("kernel-file")
-                .value_name("FILE")
-                .value_hint(ValueHint::FilePath)
-                .help("Path to a precompiled kernel file. Use this if you have a custom kernel or want to skip kernel compilation. \
-                       Example: /path/to/bzImage")
-                .required(false),
-        )
-        .arg(
-            Arg::new("nvidia_drivers")
-                .long("nvidia-drivers")
-                .help("Enables building NVIDIA drivers and including them in the VM image.")
-                .required(false)
-                .action(clap::ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("kernel_module")
-                .long("kernel-module")
-                .value_name("MODULENAME")
-                .help("[MIA] Load kernel module. \
-                       MODULENAME will be passed to modprobe. \
-                       This option can't be used together with --init or --init-args.")
-                .action(clap::ArgAction::Append)
-                .conflicts_with_all(["init", "init_args"])
-                .required(false)
-        )
-        .arg(
-            Arg::new("mount")
-                .long("mount")
-                .value_name("source:target|source:target:fstype:options")
-                .help("[MIA] Mount directory on startup. Example: input:/mnt/input\n\
-                       These options are passed to MIA to mount before running any commands. Arguments are corresponding\n\
-                       to mount syscall. If no <fstype> is specified, MIA will use 9p by default.\n\
-                       MIA will mount /proc by default. If you don't want this, use --no-default-mounts.\n\
-                       This option can't be used together with --init or --init-args.")
-                .action(clap::ArgAction::Append)
-                .conflicts_with_all(["init", "init_args"])
-                .required(false),
-        )
-        .arg(
-            Arg::new("mia_version")
-                .long("mia-version")
-                .value_name("STRING")
-                .help("[MIA] Install specified MIA version.")
-                .long_help("[MIA] Install specified MIA version.\n\
-                            Accepted format is from mia-installer. Examples:\n\
-                            - latest\n\
-                            - 0.1.0\n\
-                            - file:/path/to/mia/binary\n\
-                            This option can't be used together with --init or --init-args.")
-                .conflicts_with_all(["init", "init_args"])
-                .required(false)
-                .default_value("latest"),
-        )
-        .arg(
-            Arg::new("no_gevulot_runtime")
-                .long("no-gevulot-runtime")
-                .help("[MIA] Don't install Gevulot runtime. Only for debug purposes.")
-                .long_help("[MIA] Don't install Gevulot runtime. Only for debug purposes.\n\
-                       No following config will be provided to the VM. Only built-in one will be used.\n\
-                       No input/output context directories will be mounted.\n\
-                       Note: Gevulot worker will provide runtime config through gevulot-rt-config.\n\
-                       This means that images with this flag enabled cannot be executed on the network.\n\
-                       This option can't be used together with --init or --init-args.")
-                .action(clap::ArgAction::SetTrue)
-                .conflicts_with_all(["init", "init_args"])
-                .required(false),
-        )
-        .arg(
-            Arg::new("no_default_mounts")
-                .long("no-default-mounts")
-                .help("[MIA] Don't mount /proc. \
-                       This option can't be used together with --init or --init-args.")
-                .action(clap::ArgAction::SetTrue)
-                .conflicts_with_all(["init", "init_args"])
-                .required(false),
-        )
-        .arg(
-            Arg::new("init")
-                .short('i')
-                .long("init")
-                .value_name("INIT")
-                .value_hint(ValueHint::FilePath)
-                .help("Init process to use (e.g., /sbin/init, /lib/systemd/systemd). This is the first process started by the kernel.")
-                .required(false),
-        )
-        .arg(
-            Arg::new("init_args")
-                .long("init-args")
-                .value_name("ARGS")
-                .help("Arguments to pass to the init program. Example: '--debug --option=value'")
-                .allow_hyphen_values(true)
-                .required(false),
-        )
-        .arg(
-            Arg::new("rw_root")
-                .long("rw-root")
-                .help("Mount root filesystem as read-write. Only for debug purposes.")
-                .long_help("Mount root filesystem as read-write. Only for debug purposes.\n\
-                            Root filesystem will be mounted as read-only by default.\n\
-                            Note: Gevulot worker node will execute your disk image in read-only mode.\n\
-                            This means that images with this flag enabled cannot be executed on the network.")
-                .required(false)
-                .action(clap::ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("mbr_file")
-                .long("mbr-file")
-                .value_name("FILE")
-                .value_hint(ValueHint::FilePath)
-                .help("Path to MBR file. If none provided, following paths will be tried:\n\
-                        - /usr/share/syslinux/mbr.bin\n\
-                        - /usr/lib/syslinux/mbr/mbr.bin\n\
-                        - /usr/lib/syslinux/bios/mbr.bin")
-                .required(false),
-        )
-        .arg(
-            Arg::new("output_file")
-                .short('o')
-                .long("output")
-                .value_name("FILE")
-                .value_hint(ValueHint::FilePath)
-                .help("Name of the output disk image file. This will be a bootable disk image you can use with QEMU or other VM software.")
-                .required(false)
-                .default_value("disk.img"),
-        )
-        .arg(
-            Arg::new("force")
-                .long("force")
-                .help("Force the build and try to fix known problems along the way. This will overwrite existing files and attempt to clean up previous build artifacts.")
-                .required(false)
-                .action(clap::ArgAction::SetTrue),
-        )
-        .arg(
-            Arg::new("quiet")
-                .short('q')
-                .long("quiet")
-                .help("Do not print any messages.")
-                .required(false)
-                .action(clap::ArgAction::SetTrue),
-        )
+/// Build command.
+#[derive(Clone, Debug, clap::Parser)]
+pub struct BuildArgs {
+    /// Image to use as a source for VM filesystem.
+    #[command(flatten)]
+    pub image: Image,
+
+    /// Size of the disk image (e.g., 10G, 1024M).
+    ///
+    /// This determines the total capacity of the VM's virtual disk.
+    #[arg(long, short = 's', value_name = "SIZE", default_value = "10G")]
+    pub image_size: String,
+
+    /// Linux kernel version to use (e.g., v6.10).
+    ///
+    /// Use 'latest' for the most recent version. This kernel will be compiled from source.
+    #[arg(
+        long = "kernel",
+        short = 'k',
+        value_name = "VERSION",
+        default_value = "v6.12"
+    )]
+    pub kernel_version: String,
+
+    /// URL of the Linux kernel repository to clone.
+    ///
+    /// Change this if you want to use a fork or mirror.
+    #[arg(
+        long,
+        value_name = "URL",
+        value_hint = ValueHint::Url,
+        default_value = "https://github.com/torvalds/linux.git"
+    )]
+    pub kernel_url: String,
+
+    /// Path to a precompiled kernel file.
+    ///
+    /// Use this if you have a custom kernel or want to skip kernel compilation.
+    /// Example: /path/to/bzImage
+    #[arg(long, value_name = "FILE", value_hint = ValueHint::FilePath)]
+    pub kernel_file: Option<String>,
+
+    /// Enables building NVIDIA drivers and including them in the VM image.
+    #[arg(long)]
+    pub nvidia_drivers: bool,
+
+    /// [MIA] Load kernel module. Can be passed multiple times.
+    ///
+    /// MODULENAME will be passed to modprobe.
+    /// This option can't be used together with --init or --init-args.
+    #[arg(long, value_name = "MODULENAME", conflicts_with_all = ["init", "init_args"])]
+    pub kernel_modules: Vec<String>,
+
+    /// Mount directory on startup. Can be passed multiple times.
+    ///
+    /// Example: input:/mnt/input
+    ///
+    /// These options are passed to MIA to mount before running any commands. Arguments are
+    /// corresponding to mount syscall. If no <fstype> is specified, MIA will use 9p by default.
+    ///
+    /// MIA will mount /proc by default. If you don't want this, use --no-default-mounts.
+    ///
+    /// This option can't be used together with --init or --init-args.
+    #[arg(
+        long = "mount",
+        value_name = "source:target|source:target:fstype:options",
+        conflicts_with_all = ["init", "init_args"]
+    )]
+    pub mounts: Vec<String>,
+
+    /// [MIA] Install specified MIA version.
+    ///
+    /// Accepted format is from mia-installer.
+    /// Examples:
+    /// - latest
+    /// - 0.1.0
+    /// - file:/path/to/mia/binary
+    ///
+    /// This option can't be used together with --init or --init-args.
+    #[arg(
+        long,
+        value_name = "STRING",
+        default_value = "latest",
+        conflicts_with_all = ["init", "init_args"],
+        verbatim_doc_comment
+    )]
+    pub mia_version: String,
+
+    /// [MIA] Don't install Gevulot runtime. Only for debug purposes.
+    ///
+    /// No following config will be provided to the VM. Only built-in one will be used.
+    /// No input/output context directories will be mounted.
+    ///
+    /// *Note:* Gevulot worker will provide runtime config through gevulot-rt-config.
+    /// This means that images with this flag enabled cannot be executed on the network.
+    ///
+    /// This option can't be used together with --init or --init-args.
+    #[arg(hide = true, long, conflicts_with_all = ["init", "init_args"])]
+    pub no_gevulot_runtime: bool,
+
+    /// [MIA] Don't mount /proc.
+    ///
+    /// This option can't be used together with --init or --init-args.
+    #[arg(long, conflicts_with_all = ["init", "init_args"])]
+    pub no_default_mounts: bool,
+
+    /// Init process to use (e.g., /sbin/init, /lib/systemd/systemd).
+    ///
+    /// This is the first process started by the kernel.
+    #[arg(long, short = 'i', value_name = "INIT", value_hint = ValueHint::FilePath)]
+    pub init: Option<String>,
+
+    /// Arguments to pass to the init program.
+    ///
+    /// Example: '--debug --option=value'
+    #[arg(long, value_name = "ARGS", allow_hyphen_values = true)]
+    pub init_args: Option<String>,
+
+    /// Mount root filesystem as read-write. Only for debug purposes.
+    ///
+    /// Root filesystem will be mounted as read-only by default.
+    ///
+    /// *Note:* Gevulot worker node will execute your disk image in read-only mode.
+    /// This means that images with this flag enabled cannot be executed on the network.
+    #[arg(hide = true, long)]
+    pub rw_root: bool,
+
+    /// Path to MBR file.
+    ///
+    /// If none provided, following paths will be tried:
+    /// - /usr/share/syslinux/mbr.bin
+    /// - /usr/lib/syslinux/mbr/mbr.bin
+    /// - /usr/lib/syslinux/bios/mbr.bin
+    #[arg(long, value_name = "FILE", value_hint = ValueHint::FilePath, verbatim_doc_comment)]
+    pub mbr_file: Option<PathBuf>,
+
+    /// Name of the output disk image file.
+    ///
+    /// This will be a bootable disk image you can use with QEMU or other VM software.
+    #[arg(
+        long,
+        short,
+        value_name = "FILE",
+        value_hint = ValueHint::FilePath,
+        default_value = "disk.img"
+    )]
+    pub output_file: PathBuf,
+
+    /// Force the build and try to fix known problems along the way.
+    ///
+    /// This will overwrite existing files and attempt to clean up previous build artifacts.
+    #[arg(long)]
+    pub force: bool,
+
+    /// Do not print any messages.
+    #[arg(long, short)]
+    pub quiet: bool,
 }
 
-pub async fn build(matches: &clap::ArgMatches) -> Result<()> {
-    let options = BuildOptions::try_from(matches).map_err(|e| anyhow::anyhow!(e))?;
+#[derive(Clone, Debug, clap::Args)]
+#[group(required = true)]
+pub struct Image {
+    /// Container image to use as the source.
+    ///
+    /// Supports various transport methods:
+    /// - docker: Docker registry (e.g., docker://docker.io/debian:latest)
+    /// - containers-storage: Local container storage (e.g., containers-storage:localhost/myimage:latest)
+    /// - dir: Local directory (e.g., dir:/path/to/image)
+    /// - oci: OCI image layout (e.g., oci:/path/to/layout)
+    /// - docker-archive: Docker archive (e.g., docker-archive:/path/to/archive.tar)
+    ///
+    /// Examples:
+    /// - docker://docker.io/ubuntu:20.04
+    /// - containers-storage:localhost/custom-image:latest
+    #[arg(long, short = 'c', value_name = "IMAGE", verbatim_doc_comment)]
+    pub container: Option<String>,
+
+    /// Directory containing the root filesystem to use.
+    ///
+    /// This should be a fully prepared root filesystem, typically extracted from a container or
+    /// created manually.
+    #[arg(long, value_name = "DIR", value_hint = ValueHint::FilePath)]
+    pub rootfs_dir: Option<PathBuf>,
+
+    /// Path to a Containerfile (Dockerfile) to build the container image.
+    ///
+    /// The file will be used to build a new image which will then be used as the source.
+    #[arg(long, short = 'f', value_name = "FILE", value_hint = ValueHint::FilePath)]
+    pub containerfile: Option<PathBuf>,
+}
+
+impl BuildArgs {
+    /// Run build subcommand.
+    pub async fn run(&self, _format: OutputFormat) -> Result<(), Box<dyn std::error::Error>> {
+        build(self).await
+    }
+}
+
+async fn build(build_args: &BuildArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let options = BuildOptions::from(build_args);
     let builder = SkopeoSyslinuxBuilder {};
-    builder.build(&options)
+    builder.build(&options)?;
+    Ok(())
 }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -14,7 +14,7 @@ pub struct BuildArgs {
     /// Size of the disk image (e.g., 10G, 1024M).
     ///
     /// This determines the total capacity of the VM's virtual disk.
-    #[arg(long, short = 's', value_name = "SIZE", default_value = "10G")]
+    #[arg(long = "size", short = 's', value_name = "SIZE", default_value = "10G")]
     pub image_size: String,
 
     /// Linux kernel version to use (e.g., v6.10).
@@ -54,7 +54,11 @@ pub struct BuildArgs {
     ///
     /// MODULENAME will be passed to modprobe.
     /// This option can't be used together with --init or --init-args.
-    #[arg(long, value_name = "MODULENAME", conflicts_with_all = ["init", "init_args"])]
+    #[arg(
+        long = "kernel-module",
+        value_name = "MODULENAME",
+        conflicts_with_all = ["init", "init_args"],
+    )]
     pub kernel_modules: Vec<String>,
 
     /// Mount directory on startup. Can be passed multiple times.
@@ -144,7 +148,7 @@ pub struct BuildArgs {
     ///
     /// This will be a bootable disk image you can use with QEMU or other VM software.
     #[arg(
-        long,
+        long = "output",
         short,
         value_name = "FILE",
         value_hint = ValueHint::FilePath,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,63 @@
+//! Gevulot Control commands definition.
+
+/// Arguments for chain-related commands.
+#[derive(Clone, Debug, clap::Args)]
+pub struct ChainArgs {
+    /// Sets the endpoint for the Gevulot client.
+    #[arg(
+        global = true,
+        long,
+        short = 'e',
+        env = "GEVULOT_ENDPOINT",
+        value_name = "URL",
+        value_hint = clap::ValueHint::Url,
+    )]
+    pub endpoint: Option<String>,
+
+    /// Sets the gas price for the Gevulot client.
+    #[arg(
+        global = true,
+        long = "gas-price",
+        short = 'g',
+        env = "GEVULOT_GAS_PRICE",
+        value_name = "PRICE"
+    )]
+    pub gas_price: Option<f64>,
+
+    /// Sets the gas multiplier for the Gevulot client.
+    #[arg(
+        global = true,
+        long = "gas-multiplier",
+        short = 'm',
+        env = "GEVULOT_GAS_MULTIPLIER",
+        value_name = "MULTIPLIER"
+    )]
+    pub gas_multiplier: Option<f64>,
+
+    /// Sets the mnemonic for the Gevulot client.
+    #[arg(
+        global = true,
+        long,
+        short = 'n',
+        env = "GEVULOT_MNEMONIC",
+        hide_env_values = true
+    )]
+    pub mnemonic: Option<String>,
+
+    /// Sets the password for the Gevulot client.
+    #[arg(
+        global = true,
+        long,
+        short = 'p',
+        env = "GEVULOT_PASSWORD",
+        hide_env_values = true
+    )]
+    pub password: Option<String>,
+}
+
 pub mod build;
 pub mod pins;
+pub mod sudo;
 pub mod tasks;
 pub mod workers;
-pub mod sudo;
+pub mod workflow;

--- a/src/commands/pins.rs
+++ b/src/commands/pins.rs
@@ -62,6 +62,7 @@ enum Subcommand {
         worker_id: String,
 
         /// Success.
+        #[arg(long)]
         success: bool,
     },
 

--- a/src/commands/pins.rs
+++ b/src/commands/pins.rs
@@ -1,49 +1,114 @@
-use gevulot_rs::builders::{ByteSize, ByteUnit, MsgCreatePinBuilder, MsgDeletePinBuilder, MsgAckPinBuilder};
+use gevulot_rs::builders::{
+    ByteSize, ByteUnit, MsgAckPinBuilder, MsgCreatePinBuilder, MsgDeletePinBuilder,
+};
+use patharg::InputArg;
+use serde_json::Value;
+use std::path::Path;
 
-use crate::{connect_to_gevulot, print_object, read_file};
+use crate::{connect_to_gevulot, print_object, read_file, ChainArgs, OutputFormat};
+
+/// Pins command.
+#[derive(Clone, Debug, clap::Parser)]
+pub struct Command {
+    #[command(flatten)]
+    chain_args: ChainArgs,
+
+    #[command(subcommand)]
+    subcommand: Subcommand,
+}
+
+impl Command {
+    /// Match pin subcommand and run it.
+    pub async fn run(&self, format: OutputFormat) -> Result<(), Box<dyn std::error::Error>> {
+        let value = match &self.subcommand {
+            Subcommand::List => list_pins(&self.chain_args).await,
+            Subcommand::Get { cid } => get_pin(&self.chain_args, cid).await,
+            Subcommand::Ack {
+                cid,
+                id,
+                worker_id,
+                success,
+            } => ack_pin(&self.chain_args, id, cid, worker_id, *success).await,
+            Subcommand::Create { file } => {
+                create_pin(&self.chain_args, file.path_ref().map(|v| &**v)).await
+            }
+            Subcommand::Delete { cid } => delete_pin(&self.chain_args, cid).await,
+        }?;
+        print_object(format, &value)
+    }
+}
+
+/// Pin subcommand.
+#[derive(Clone, Debug, clap::Subcommand)]
+enum Subcommand {
+    /// List all pins.
+    List,
+
+    /// Get a specific pin.
+    Get {
+        /// The CID of the pin to retrieve.
+        cid: String,
+    },
+
+    /// Ack a pin
+    Ack {
+        /// The ID of the pin to ack.
+        id: String,
+
+        /// The CID of the pin to ack.
+        cid: String,
+
+        /// The ID of the worker.
+        worker_id: String,
+
+        /// Success.
+        success: bool,
+    },
+
+    /// Create a new pin.
+    Create {
+        /// The file to read the pin data from or '-' to read from stdin.
+        #[arg(short, long, default_value_t)]
+        file: InputArg,
+    },
+
+    /// Delete a pin.
+    Delete {
+        /// The CID of the pin to delete.
+        cid: String,
+    },
+}
 
 /// Lists all pins in the Gevulot network
-///
-/// This function connects to the Gevulot network, retrieves all pins,
-/// and prints them as YAML output.
-///
-/// # Arguments
-///
-/// * `_sub_m` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///              This is used to access any additional flags or options passed to the command.
-pub async fn list_pins(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = connect_to_gevulot(_sub_m).await?;
+async fn list_pins(chain_args: &ChainArgs) -> Result<Value, Box<dyn std::error::Error>> {
+    let mut client = connect_to_gevulot(chain_args).await?;
     let pins = client.pins.list().await?;
     // Convert the pins to the gevulot_rs::models::Pin type
     let pins: Vec<gevulot_rs::models::Pin> = pins.into_iter().map(Into::into).collect();
-    print_object(_sub_m, &pins)?;
-    Ok(())
+    Ok(serde_json::json!(pins))
 }
 
 /// Retrieves a specific pin from the Gevulot network
-///
-/// This function connects to the Gevulot network, retrieves a pin by its CID,
-/// and prints it as YAML output.
-///
-/// # Arguments
-///
-/// * `_sub_m` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///              This is used to access the CID of the pin to retrieve and any additional options.
-pub async fn get_pin(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = connect_to_gevulot(_sub_m).await?;
-    if let Some(pin_cid) = _sub_m.get_one::<String>("cid") {
-        let pin = client.pins.get(pin_cid).await?;
-        // Convert the pin to the gevulot_rs::models::Pin type
-        let pin: gevulot_rs::models::Pin = pin.into();
-        print_object(_sub_m, &pin)?;
-    } else {
-        println!("Pin CID is required");
-    }
-    Ok(())
+async fn get_pin(
+    chain_args: &ChainArgs,
+    pin_cid: &str,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let mut client = connect_to_gevulot(chain_args).await?;
+    let pin = client.pins.get(pin_cid).await?;
+    // Convert the pin to the gevulot_rs::models::Pin type
+    let pin: gevulot_rs::models::Pin = pin.into();
+    Ok(serde_json::json!(pin))
 }
 
-pub async fn ack_pin(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = connect_to_gevulot(_sub_m).await?;
+/// Ack a specific pin
+async fn ack_pin(
+    chain_args: &ChainArgs,
+    pin_id: &str,
+    pin_cid: &str,
+    worker_id: &str,
+    success: bool,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let mut client = connect_to_gevulot(chain_args).await?;
     let me = client
         .base_client
         .write()
@@ -51,40 +116,29 @@ pub async fn ack_pin(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error
         .address
         .clone()
         .ok_or("No address found, did you set a mnemonic?")?;
-    let pin_id = _sub_m.get_one::<String>("id").ok_or("Pin ID is required")?;
-    let pin_cid = _sub_m
-        .get_one::<String>("cid")
-        .ok_or("Pin CID is required")?;
-    let worker_id = _sub_m.get_one::<String>("worker_id").ok_or("Worker ID is required")?;
-    let success = _sub_m.get_flag("success");
     client
         .pins
         .ack(
             MsgAckPinBuilder::default()
-                .id(pin_id.clone())
+                .id(pin_id.to_string())
                 .creator(me.clone())
-                .cid(pin_cid.clone())
-                .worker_id(worker_id.clone())
+                .cid(pin_cid.to_string())
+                .worker_id(worker_id.to_string())
                 .success(success)
                 .into_message()?,
         )
         .await?;
-    Ok(())
+    Ok(serde_json::json!({}))
 }
 
 /// Creates a new pin in the Gevulot network
-///
-/// This function reads pin data from a file, connects to the Gevulot network,
-/// and creates a new pin with the provided data.
-///
-/// # Arguments
-///
-/// * `_sub_m` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///              This is used to access the file path for pin data and any additional options.
-pub async fn create_pin(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+async fn create_pin(
+    chain_args: &ChainArgs,
+    file: Option<&Path>,
+) -> Result<Value, Box<dyn std::error::Error>> {
     // Read pin data from file
-    let pin: gevulot_rs::models::Pin = read_file(_sub_m).await?;
-    let mut client = connect_to_gevulot(_sub_m).await?;
+    let pin: gevulot_rs::models::Pin = read_file(file).await?;
+    let mut client = connect_to_gevulot(chain_args).await?;
 
     // Get the client's address
     let me = client
@@ -114,28 +168,19 @@ pub async fn create_pin(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::er
         )
         .await?;
 
-    // Replace println with print_object for consistent formatting
-    print_object(_sub_m, &serde_json::json!({
+    Ok(serde_json::json!({
         "status": "success",
         "message": format!("Created pin with id: {}", resp.id),
         "id": resp.id,
-    }))?;
-    Ok(())
+    }))
 }
 
 /// Deletes a pin from the Gevulot network
-///
-/// This function connects to the Gevulot network and deletes a pin specified by its CID.
-///
-/// # Arguments
-///
-/// * `_sub_m` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///              This is used to access the CID of the pin to delete and any additional options.
-pub async fn delete_pin(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let pin_cid = _sub_m
-        .get_one::<String>("cid")
-        .ok_or("Pin CID is required")?;
-    let mut client = connect_to_gevulot(_sub_m).await?;
+async fn delete_pin(
+    chain_args: &ChainArgs,
+    pin_cid: &str,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let mut client = connect_to_gevulot(chain_args).await?;
 
     // Get the client's address
     let me = client
@@ -152,15 +197,13 @@ pub async fn delete_pin(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::er
         .delete(
             MsgDeletePinBuilder::default()
                 .creator(me.clone())
-                .cid(pin_cid.clone())
+                .cid(pin_cid.to_string())
                 .into_message()?,
         )
         .await?;
 
-    // Use print_object for consistent formatting
-    print_object(_sub_m, &serde_json::json!({
+    Ok(serde_json::json!({
         "status": "success",
         "message": format!("Deleted pin with CID: {}", pin_cid)
-    }))?;
-    Ok(())
+    }))
 }

--- a/src/commands/sudo.rs
+++ b/src/commands/sudo.rs
@@ -1,184 +1,129 @@
-use clap::{Arg, Command, ValueHint};
 use gevulot_rs::proto::gevulot::gevulot::{
     MsgSudoDeletePin, MsgSudoDeleteTask, MsgSudoDeleteWorker, MsgSudoFreezeAccount,
 };
+use serde_json::Value;
 
-use crate::{connect_to_gevulot, print_object};
+use crate::{connect_to_gevulot, print_object, ChainArgs, OutputFormat};
 
-pub fn get_command(chain_args: &[Arg]) -> clap::Command {
-    Command::new("sudo")
-        .about("Perform administrative operations with sudo privileges")
-        .subcommand_required(true)
-        .subcommand(
-            Command::new("delete-pin")
-                .about("Delete a pin using sudo privileges")
-                .arg(
-                    Arg::new("id")
-                        .value_name("ID")
-                        .help("The ID of the pin to delete")
-                        .required(true)
-                        .index(1)
-                        .value_hint(ValueHint::Other),
-                )
-                .args(chain_args),
-        )
-        .subcommand(
-            Command::new("delete-worker")
-                .about("Delete a worker using sudo privileges")
-                .arg(
-                    Arg::new("id")
-                        .value_name("ID")
-                        .help("The ID of the worker to delete")
-                        .required(true)
-                        .index(1)
-                        .value_hint(ValueHint::Other),
-                )
-                .args(chain_args),
-        )
-        .subcommand(
-            Command::new("delete-task")
-                .about("Delete a task using sudo privileges")
-                .arg(
-                    Arg::new("id")
-                        .value_name("ID")
-                        .help("The ID of the task to delete")
-                        .required(true)
-                        .index(1)
-                        .value_hint(ValueHint::Other),
-                )
-                .args(chain_args),
-        )
-        .subcommand(
-            Command::new("freeze-account")
-                .about("Freeze an account using sudo privileges")
-                .arg(
-                    Arg::new("address")
-                        .value_name("ADDRESS")
-                        .help("The address of the account to freeze")
-                        .required(true)
-                        .index(1)
-                        .value_hint(ValueHint::Other),
-                )
-                .args(chain_args),
-        )
+/// Sudo command.
+#[derive(Clone, Debug, clap::Parser)]
+pub struct Command {
+    #[command(flatten)]
+    chain_args: ChainArgs,
+
+    #[command(subcommand)]
+    subcommand: Subcommand,
+}
+
+impl Command {
+    /// Match sudo subcommand and run it.
+    pub async fn run(&self, format: OutputFormat) -> Result<(), Box<dyn std::error::Error>> {
+        let value = match &self.subcommand {
+            Subcommand::DeletePin { id } => sudo_delete_pin(&self.chain_args, id.clone()).await,
+            Subcommand::DeleteWorker { id } => {
+                sudo_delete_worker(&self.chain_args, id.clone()).await
+            }
+            Subcommand::DeleteTask { id } => sudo_delete_task(&self.chain_args, id.clone()).await,
+            Subcommand::FreezeAccount { address } => {
+                sudo_freeze_account(&self.chain_args, address.clone()).await
+            }
+        }?;
+        print_object(format, &value)
+    }
+}
+
+/// Sudo subcommand.
+#[derive(Clone, Debug, clap::Subcommand)]
+enum Subcommand {
+    /// Delete a pin using sudo privileges.
+    DeletePin {
+        /// The ID of the pin to delete.
+        id: String,
+    },
+
+    /// Delete a worker using sudo privileges.
+    DeleteWorker {
+        /// The ID of the worker to delete.
+        id: String,
+    },
+
+    /// Delete a task using sudo privileges.
+    DeleteTask {
+        /// The ID of the task to delete.
+        id: String,
+    },
+
+    /// Freeze an account using sudo privileges.
+    FreezeAccount {
+        /// The address of the account to freeze.
+        address: String,
+    },
 }
 
 /// Deletes a pin using sudo privileges.
-///
-/// # Arguments
-///
-/// * `_sub_m` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///
-/// # Returns
-///
-/// A Result containing () if successful, or a Box<dyn std::error::Error> if an error occurs.
-pub async fn sudo_delete_pin(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = connect_to_gevulot(_sub_m).await?;
-    if let Some(pin_id) = _sub_m.get_one::<String>("id") {
-        let msg = MsgSudoDeletePin {
-            authority: client.base_client.write().await.address.clone().unwrap(),
-            cid: pin_id.clone(),
-        };
-        client.sudo.delete_pin(msg).await?;
-        print_object(_sub_m, &serde_json::json!({
-            "status": "success",
-            "message": "Pin deleted successfully"
-        }))?;
-    } else {
-        print_object(_sub_m, &serde_json::json!({
-            "status": "error",
-            "message": "Pin ID is required"
-        }))?;
-    }
-    Ok(())
+async fn sudo_delete_pin(
+    chain_args: &ChainArgs,
+    cid: String,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let mut client = connect_to_gevulot(chain_args).await?;
+    let msg = MsgSudoDeletePin {
+        authority: client.base_client.write().await.address.clone().unwrap(),
+        cid,
+    };
+    client.sudo.delete_pin(msg).await?;
+    Ok(serde_json::json!({
+        "status": "success",
+        "message": "Pin deleted successfully"
+    }))
 }
 
 /// Deletes a worker using sudo privileges.
-///
-/// # Arguments
-///
-/// * `_sub_m` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///
-/// # Returns
-///
-/// A Result containing () if successful, or a Box<dyn std::error::Error> if an error occurs.
-pub async fn sudo_delete_worker(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = connect_to_gevulot(_sub_m).await?;
-    if let Some(worker_id) = _sub_m.get_one::<String>("id") {
-        let msg = MsgSudoDeleteWorker {
-            authority: client.base_client.write().await.address.clone().unwrap(),
-            id: worker_id.clone(),
-        };
-        client.sudo.delete_worker(msg).await?;
-        print_object(_sub_m, &serde_json::json!({
-            "status": "success",
-            "message": "Worker deleted successfully"
-        }))?;
-    } else {
-        print_object(_sub_m, &serde_json::json!({
-            "status": "error",
-            "message": "Worker ID is required"
-        }))?;
-    }
-    Ok(())
+async fn sudo_delete_worker(
+    chain_args: &ChainArgs,
+    worker_id: String,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let mut client = connect_to_gevulot(chain_args).await?;
+    let msg = MsgSudoDeleteWorker {
+        authority: client.base_client.write().await.address.clone().unwrap(),
+        id: worker_id,
+    };
+    client.sudo.delete_worker(msg).await?;
+    Ok(serde_json::json!({
+        "status": "success",
+        "message": "Worker deleted successfully"
+    }))
 }
 
 /// Deletes a task using sudo privileges.
-///
-/// # Arguments
-///
-/// * `_sub_m` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///
-/// # Returns
-///
-/// A Result containing () if successful, or a Box<dyn std::error::Error> if an error occurs.
-pub async fn sudo_delete_task(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = connect_to_gevulot(_sub_m).await?;
-    if let Some(task_id) = _sub_m.get_one::<String>("id") {
-        let msg = MsgSudoDeleteTask {
-            authority: client.base_client.write().await.address.clone().unwrap(),
-            id: task_id.clone(),
-        };
-        client.sudo.delete_task(msg).await?;
-        print_object(_sub_m, &serde_json::json!({
-            "status": "success",
-            "message": "Task deleted successfully"
-        }))?;
-    } else {
-        print_object(_sub_m, &serde_json::json!({
-            "status": "error",
-            "message": "Task ID is required"
-        }))?;
-    }
-    Ok(())
+async fn sudo_delete_task(
+    chain_args: &ChainArgs,
+    task_id: String,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let mut client = connect_to_gevulot(chain_args).await?;
+    let msg = MsgSudoDeleteTask {
+        authority: client.base_client.write().await.address.clone().unwrap(),
+        id: task_id,
+    };
+    client.sudo.delete_task(msg).await?;
+    Ok(serde_json::json!({
+        "status": "success",
+        "message": "Task deleted successfully"
+    }))
 }
 
 /// Freezes an account using sudo privileges.
-///
-/// # Arguments
-///
-/// * `_sub_m` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///
-/// # Returns
-///
-/// A Result containing () if successful, or a Box<dyn std::error::Error> if an error occurs.
-pub async fn sudo_freeze_account(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = connect_to_gevulot(_sub_m).await?;
-    if let Some(account) = _sub_m.get_one::<String>("account") {
-        let msg = MsgSudoFreezeAccount {
-            authority: client.base_client.write().await.address.clone().unwrap(),
-            account: account.clone(),
-        };
-        client.sudo.freeze_account(msg).await?;
-        print_object(_sub_m, &serde_json::json!({
-            "status": "success",
-            "message": "Account frozen successfully"
-        }))?;
-    } else {
-        print_object(_sub_m, &serde_json::json!({
-            "status": "error",
-            "message": "Account address is required"
-        }))?;
-    }
-    Ok(())
+async fn sudo_freeze_account(
+    chain_args: &ChainArgs,
+    account: String,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let mut client = connect_to_gevulot(chain_args).await?;
+    let msg = MsgSudoFreezeAccount {
+        authority: client.base_client.write().await.address.clone().unwrap(),
+        account,
+    };
+    client.sudo.freeze_account(msg).await?;
+    Ok(serde_json::json!({
+        "status": "success",
+        "message": "Account frozen successfully"
+    }))
 }

--- a/src/commands/tasks.rs
+++ b/src/commands/tasks.rs
@@ -74,7 +74,7 @@ enum Subcommand {
     /// Create a new task.
     Create {
         /// The file to read the task data from or '-' to read from stdin.
-        #[arg(default_value_t)]
+        #[arg(short, long, default_value_t)]
         file: InputArg,
     },
 

--- a/src/commands/tasks.rs
+++ b/src/commands/tasks.rs
@@ -1,56 +1,144 @@
+use patharg::InputArg;
+use serde_json::Value;
 use std::collections::HashMap;
+use std::path::Path;
 
 use gevulot_rs::builders::{
     ByteSize, ByteUnit, MsgAcceptTaskBuilder, MsgCreateTaskBuilder, MsgDeclineTaskBuilder,
     MsgFinishTaskBuilder,
 };
 
-use crate::{connect_to_gevulot, print_object, read_file};
+use crate::{connect_to_gevulot, print_object, read_file, ChainArgs, OutputFormat};
+
+/// Tasks command.
+#[derive(Clone, Debug, clap::Parser)]
+pub struct Command {
+    #[command(flatten)]
+    chain_args: ChainArgs,
+
+    #[command(subcommand)]
+    subcommand: Subcommand,
+}
+
+impl Command {
+    /// Match task subcommand and run it.
+    pub async fn run(&self, format: OutputFormat) -> Result<(), Box<dyn std::error::Error>> {
+        let value = match &self.subcommand {
+            Subcommand::List => list_tasks(&self.chain_args).await,
+            Subcommand::Get { id } => get_task(&self.chain_args, id).await,
+            Subcommand::Create { file } => {
+                create_task(&self.chain_args, file.path_ref().map(|v| &**v)).await
+            }
+            Subcommand::Accept { id, worker_id } => {
+                accept_task(&self.chain_args, id, worker_id).await
+            }
+            Subcommand::Decline { id, worker_id } => {
+                decline_task(&self.chain_args, id, worker_id).await
+            }
+            Subcommand::Finish {
+                id,
+                exit_code,
+                stdout,
+                stderr,
+                error,
+                output_contexts,
+            } => {
+                finish_task(
+                    &self.chain_args,
+                    id,
+                    *exit_code,
+                    stdout.as_ref(),
+                    stderr.as_ref(),
+                    error.as_ref(),
+                    output_contexts.as_ref(),
+                )
+                .await
+            }
+        }?;
+        print_object(format, &value)
+    }
+}
+
+/// Task subcommand.
+#[derive(Clone, Debug, clap::Subcommand)]
+enum Subcommand {
+    /// List all tasks.
+    List,
+
+    /// Get a specific task.
+    Get {
+        /// The ID of the task to retrieve.
+        id: String,
+    },
+
+    /// Create a new task.
+    Create {
+        /// The file to read the task data from or '-' to read from stdin.
+        #[arg(default_value_t)]
+        file: InputArg,
+    },
+
+    /// Accept a task (you probably should not use this).
+    #[command(hide = true)]
+    Accept {
+        /// The ID of the task to accept.
+        id: String,
+
+        /// The ID of the worker accepting the task.
+        worker_id: String,
+    },
+
+    /// Decline a task (you probably should not use this).
+    #[command(hide = true)]
+    Decline {
+        /// The ID of the task to decline.
+        id: String,
+
+        /// The ID of the worker declining the task.
+        worker_id: String,
+    },
+
+    /// Finish a task (you probably should not use this).
+    #[command(hide = false)]
+    Finish {
+        /// The ID of the task to finish.
+        id: String,
+
+        /// The exit code of the task.
+        #[arg(default_value_t)]
+        exit_code: i32,
+
+        /// The stdout output of the task.
+        stdout: Option<String>,
+
+        /// The stderr output of the task.
+        stderr: Option<String>,
+
+        /// Any error message from the task.
+        error: Option<String>,
+
+        /// Output contexts produced by the task.
+        output_contexts: Option<Vec<String>>,
+    },
+}
 
 /// Lists all tasks.
-///
-/// # Arguments
-///
-/// * `_sub_m` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///              This is used to connect to Gevulot and determine the output format.
-///
-/// # Returns
-///
-/// A Result indicating success or an error if the task listing fails.
-pub async fn list_tasks(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = connect_to_gevulot(_sub_m).await?;
+async fn list_tasks(chain_args: &ChainArgs) -> Result<Value, Box<dyn std::error::Error>> {
+    let mut client = connect_to_gevulot(chain_args).await?;
     let tasks = client.tasks.list().await?;
     let tasks: Vec<gevulot_rs::models::Task> = tasks.into_iter().map(Into::into).collect();
-    print_object(_sub_m, &tasks)?;
-    Ok(())
+    Ok(serde_json::json!(tasks))
 }
 
 /// Retrieves and displays information for a specific task.
-///
-/// # Arguments
-///
-/// * `_sub_m` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///              This includes the task ID to retrieve and is used to connect to Gevulot and determine the output format.
-///
-/// # Returns
-///
-/// A Result indicating success or an error if the task retrieval fails.
-pub async fn get_task(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = crate::connect_to_gevulot(_sub_m).await?;
-    if let Some(task_id) = _sub_m.get_one::<String>("id") {
-        let task = client.tasks.get(task_id).await?;
-        let task: gevulot_rs::models::Task = task.into();
-        print_object(_sub_m, &task)?;
-    } else {
-        print_object(
-            _sub_m,
-            &serde_json::json!({
-                "status": "error",
-                "message": "Task ID is required"
-            }),
-        )?;
-    }
-    Ok(())
+async fn get_task(
+    chain_args: &ChainArgs,
+    task_id: &str,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let mut client = crate::connect_to_gevulot(chain_args).await?;
+    let task = client.tasks.get(task_id).await?;
+    let task: gevulot_rs::models::Task = task.into();
+    Ok(serde_json::json!(task))
 }
 
 /// Creates a new task based on the provided specification.
@@ -63,9 +151,12 @@ pub async fn get_task(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::erro
 /// # Returns
 ///
 /// A Result indicating success or an error if the task creation fails.
-pub async fn create_task(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let task: gevulot_rs::models::Task = read_file(_sub_m).await?;
-    let mut client = connect_to_gevulot(_sub_m).await?;
+pub async fn create_task(
+    chain_args: &ChainArgs,
+    path: Option<&Path>,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let task: gevulot_rs::models::Task = read_file(path).await?;
+    let mut client = connect_to_gevulot(chain_args).await?;
     let me = client
         .base_client
         .write()
@@ -118,19 +209,19 @@ pub async fn create_task(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::e
         )
         .await?;
 
-    print_object(
-        _sub_m,
-        &serde_json::json!({
-            "status": "success",
-            "message": "Task created successfully",
-            "task_id": resp.id
-        }),
-    )?;
-    Ok(())
+    Ok(serde_json::json!({
+        "status": "success",
+        "message": "Task created successfully",
+        "task_id": resp.id
+    }))
 }
 
-pub async fn accept_task(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = connect_to_gevulot(_sub_m).await?;
+pub async fn accept_task(
+    chain_args: &ChainArgs,
+    task_id: &str,
+    worker_id: &str,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let mut client = connect_to_gevulot(chain_args).await?;
     let me = client
         .base_client
         .write()
@@ -139,23 +230,25 @@ pub async fn accept_task(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::e
         .clone()
         .ok_or("No address found, did you set a mnemonic?")?;
 
-    let task_id = _sub_m.get_one::<String>("id").unwrap();
-    let worker_id = _sub_m.get_one::<String>("worker_id").unwrap();
     client
         .tasks
         .accept(
             MsgAcceptTaskBuilder::default()
                 .creator(me.clone())
-                .task_id(task_id.clone())
-                .worker_id(worker_id.clone())
+                .task_id(task_id.to_string())
+                .worker_id(worker_id.to_string())
                 .into_message()?,
         )
         .await?;
-    Ok(())
+    Ok(serde_json::json!({}))
 }
 
-pub async fn decline_task(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = connect_to_gevulot(_sub_m).await?;
+pub async fn decline_task(
+    chain_args: &ChainArgs,
+    task_id: &str,
+    worker_id: &str,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let mut client = connect_to_gevulot(chain_args).await?;
     let me = client
         .base_client
         .write()
@@ -164,23 +257,29 @@ pub async fn decline_task(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::
         .clone()
         .ok_or("No address found, did you set a mnemonic?")?;
 
-    let task_id = _sub_m.get_one::<String>("id").unwrap();
-    let worker_id = _sub_m.get_one::<String>("worker_id").unwrap();
     client
         .tasks
         .decline(
             MsgDeclineTaskBuilder::default()
                 .creator(me.clone())
-                .task_id(task_id.clone())
-                .worker_id(worker_id.clone())
+                .task_id(task_id.to_string())
+                .worker_id(worker_id.to_string())
                 .into_message()?,
         )
         .await?;
-    Ok(())
+    Ok(serde_json::json!({}))
 }
 
-pub async fn finish_task(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = connect_to_gevulot(_sub_m).await?;
+pub async fn finish_task(
+    chain_args: &ChainArgs,
+    task_id: &str,
+    exit_code: i32,
+    stdout: Option<&String>,
+    stderr: Option<&String>,
+    error: Option<&String>,
+    output_contexts: Option<&Vec<String>>,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let mut client = connect_to_gevulot(chain_args).await?;
     let me = client
         .base_client
         .write()
@@ -188,36 +287,20 @@ pub async fn finish_task(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::e
         .address
         .clone()
         .ok_or("No address found, did you set a mnemonic?")?;
-
-    let task_id = _sub_m.get_one::<String>("id").unwrap();
-    let exit_code = _sub_m.get_one::<i32>("exit_code").cloned();
-    let stdout = _sub_m.get_one::<String>("stdout").cloned();
-    let stderr = _sub_m.get_one::<String>("stderr").cloned();
-    let error = _sub_m.get_one::<String>("error").cloned();
-    let output_contexts: Vec<String> = _sub_m
-        .get_many::<String>("output_contexts")
-        .unwrap_or_default()
-        .into_iter()
-        .map(|e| e.to_string())
-        .collect();
 
     client
         .tasks
         .finish(
             MsgFinishTaskBuilder::default()
                 .creator(me.clone())
-                .task_id(task_id.clone())
-                .exit_code(exit_code.unwrap_or(0))
-                .stdout(stdout)
-                .stderr(stderr)
-                .output_contexts(if output_contexts.is_empty() {
-                    None
-                } else {
-                    Some(output_contexts)
-                })
-                .error(error)
+                .task_id(task_id.to_string())
+                .exit_code(exit_code)
+                .stdout(stdout.cloned())
+                .stderr(stderr.cloned())
+                .output_contexts(output_contexts.cloned())
+                .error(error.cloned())
                 .into_message()?,
         )
         .await?;
-    Ok(())
+    Ok(serde_json::json!({}))
 }

--- a/src/commands/workflow.rs
+++ b/src/commands/workflow.rs
@@ -1,0 +1,92 @@
+use patharg::InputArg;
+use std::path::Path;
+
+use crate::ChainArgs;
+
+/// Workflow command.
+#[derive(Clone, Debug, clap::Parser)]
+pub struct Command {
+    #[command(subcommand)]
+    subcommand: Subcommand,
+}
+
+impl Command {
+    /// Match workflow subcommand and run it.
+    pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
+        match &self.subcommand {
+            Subcommand::List { chain_args } => list_workflows(chain_args).await,
+            Subcommand::Get { chain_args, id } => get_workflow(chain_args, id).await,
+            Subcommand::Create { chain_args, file } => {
+                create_workflow(chain_args, file.path_ref().map(|v| &**v)).await
+            }
+            Subcommand::Delete { chain_args, id } => delete_workflow(chain_args, id).await,
+        }
+    }
+}
+
+/// Workflow subcommand.
+#[derive(Clone, Debug, clap::Subcommand)]
+enum Subcommand {
+    /// List all workflows.
+    List {
+        /// Common chain arguments.
+        #[command(flatten)]
+        chain_args: ChainArgs,
+    },
+
+    /// Get a specific workflow.
+    Get {
+        /// Common chain arguments.
+        #[command(flatten)]
+        chain_args: ChainArgs,
+
+        /// The ID of the workflow to retrieve.
+        id: String,
+    },
+
+    /// Create a new workflow.
+    Create {
+        /// Common chain arguments.
+        #[command(flatten)]
+        chain_args: ChainArgs,
+
+        /// The file to read the workflow data from or '-' to read from stdin.
+        #[arg(short, long, default_value_t)]
+        file: InputArg,
+    },
+
+    /// Delete a workflow.
+    Delete {
+        /// Common chain arguments.
+        #[command(flatten)]
+        chain_args: ChainArgs,
+
+        /// The ID of the workflow to delete.
+        id: String,
+    },
+}
+
+async fn list_workflows(_chain_args: &ChainArgs) -> Result<(), Box<dyn std::error::Error>> {
+    todo!("Listing all workflows");
+}
+
+async fn get_workflow(
+    _chain_args: &ChainArgs,
+    _workflow_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    todo!("Getting a specific workflow");
+}
+
+async fn create_workflow(
+    _chain_args: &ChainArgs,
+    _path: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    todo!("Creating a new workflow");
+}
+
+async fn delete_workflow(
+    _chain_args: &ChainArgs,
+    _workflow_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    todo!("Deleting a workflow");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,146 @@
 use bip32::{Mnemonic, Prefix, XPrv};
-use cargo_metadata::Metadata;
-use clap::ArgAction;
-use clap::{value_parser, Arg, Command, ValueHint};
-use clap_complete::{generate, Shell};
+use clap::{CommandFactory as _, Parser as _};
+use clap_complete::Shell;
 use cosmrs::crypto::secp256k1::SigningKey;
-use gevulot_rs::gevulot_client::GevulotClientBuilder;
-use gevulot_rs::GevulotClient;
+use patharg::OutputArg;
 use rand_core::OsRng;
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
 use std::fs::File;
-use std::io::{self, Read, Write};
+use std::io::{self, Write};
+use std::path::PathBuf;
 
 mod builders;
 mod commands;
+mod utils;
+mod version;
 
-use commands::build::*;
-use commands::{pins::*, sudo::*, tasks::*, workers::*};
+use commands::*;
+use utils::*;
+use version::get_long_version;
 
-shadow_rs::shadow!(build_info);
+/// CLI interface for Gevulot Control.
+#[derive(Clone, Debug, clap::Parser)]
+#[command(version, long_version = get_long_version(), about)]
+pub struct Cli {
+    #[command(subcommand)]
+    command: Command,
+
+    /// Sets the output format.
+    #[arg(
+        global = true,
+        short = 'F',
+        long,
+        default_value_t,
+        env = "GEVULOT_FORMAT"
+    )]
+    format: OutputFormat,
+}
+
+impl Cli {
+    /// Match the command and run it.
+    pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
+        match &self.command {
+            Command::Worker(command) => command.run(self.format).await,
+            Command::Task(command) => command.run(self.format).await,
+            Command::Pin(command) => command.run(self.format).await,
+            Command::Workflow(command) => command.run().await,
+            Command::Keygen { file, password } => {
+                generate_key(file.path_ref(), password, self.format).await
+            }
+            Command::ComputeKey { mnemonic, password } => {
+                compute_key(mnemonic, password, self.format).await
+            }
+            Command::Send {
+                chain_args,
+                amount,
+                receiver,
+            } => send_tokens(chain_args, *amount, receiver, self.format).await,
+            Command::AccountInfo {
+                chain_args,
+                address,
+            } => account_info(chain_args, address, self.format).await,
+            Command::GenerateCompletion { shell, file } => {
+                generate_completion(*shell, file.path_ref()).await
+            }
+            Command::Sudo(command) => command.run(self.format).await,
+            Command::Build(build_args) => build_args.run(self.format).await,
+        }
+    }
+}
+
+/// Main commands of Gevulot Control CLI application.
+#[derive(Clone, Debug, clap::Subcommand)]
+pub enum Command {
+    /// Commands related to workers.
+    Worker(workers::Command),
+
+    /// Commands related to pins.
+    Pin(pins::Command),
+
+    /// Commands related to tasks.
+    Task(tasks::Command),
+
+    /// Commands related to workflows.
+    Workflow(workflow::Command),
+
+    /// Generate a new key.
+    Keygen {
+        /// The file to write the seed to or '-' to write to stdout.
+        #[arg(short, long, default_value_t)]
+        file: OutputArg,
+
+        /// Sets the password for the Gevulot client.
+        #[arg(short, long, default_value_t, hide_default_value = true)]
+        password: String,
+    },
+
+    /// Compute a key.
+    ComputeKey {
+        /// The mnemonic to compute the key from.
+        #[arg(long, env = "GEVULOT_MNEMONIC", hide_env_values = true)]
+        mnemonic: String,
+
+        /// The password to compute the key with.
+        #[arg(short, long, default_value_t, hide_default_value = true)]
+        password: String,
+    },
+
+    /// Send tokens to a receiver on the Gevulot network.
+    Send {
+        #[command(flatten)]
+        chain_args: ChainArgs,
+
+        /// The amount of tokens to send.
+        amount: u128,
+
+        /// The receiver address.
+        receiver: String,
+    },
+
+    /// Get the balance of the given account.
+    AccountInfo {
+        #[command(flatten)]
+        chain_args: ChainArgs,
+
+        /// The address to get the balance of.
+        address: String,
+    },
+
+    /// Generate shell completion scripts.
+    GenerateCompletion {
+        /// The shell to generate the completion scripts for.
+        shell: clap_complete::Shell,
+
+        /// The file to write the completion scripts to or '-' to write to stdout.
+        #[arg(short, long, default_value_t)]
+        file: OutputArg,
+    },
+
+    /// Perform administrative operations with sudo privileges.
+    Sudo(sudo::Command),
+
+    /// Build a VM image from a container, rootfs directory, or Containerfile.
+    Build(build::BuildArgs),
+}
 
 /// Main entry point for the Gevulot Control CLI application.
 ///
@@ -26,759 +148,22 @@ shadow_rs::shadow!(build_info);
 /// and dispatches to the appropriate subcommand handlers.
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
-
-    // Parse command-line arguments
-    let cmd = setup_command_line_args()?;
-
-    // Handle matches here
-    match cmd.get_matches().subcommand() {
-        Some(("worker", sub_m)) => match sub_m.subcommand() {
-            Some(("list", sub_m)) => list_workers(sub_m).await?,
-            Some(("get", sub_m)) => get_worker(sub_m).await?,
-            Some(("create", sub_m)) => create_worker(sub_m).await?,
-            Some(("delete", sub_m)) => delete_worker(sub_m).await?,
-            _ => println!("Unknown worker command"),
-        },
-        Some(("pin", sub_m)) => match sub_m.subcommand() {
-            Some(("list", sub_m)) => list_pins(sub_m).await?,
-            Some(("get", sub_m)) => get_pin(sub_m).await?,
-            Some(("create", sub_m)) => create_pin(sub_m).await?,
-            Some(("delete", sub_m)) => delete_pin(sub_m).await?,
-            Some(("ack", sub_m)) => ack_pin(sub_m).await?,
-            _ => println!("Unknown pin command"),
-        },
-        Some(("task", sub_m)) => match sub_m.subcommand() {
-            Some(("list", sub_m)) => list_tasks(sub_m).await?,
-            Some(("get", sub_m)) => get_task(sub_m).await?,
-            Some(("create", sub_m)) => create_task(sub_m).await?,
-            Some(("accept", sub_m)) => accept_task(sub_m).await?,
-            Some(("decline", sub_m)) => decline_task(sub_m).await?,
-            Some(("finish", sub_m)) => finish_task(sub_m).await?,
-            _ => println!("Unknown task command"),
-        },
-        Some(("workflow", sub_m)) => match sub_m.subcommand() {
-            Some(("list", sub_m)) => list_workflows(sub_m).await?,
-            Some(("get", sub_m)) => get_workflow(sub_m).await?,
-            Some(("create", sub_m)) => create_workflow(sub_m).await?,
-            Some(("delete", sub_m)) => delete_workflow(sub_m).await?,
-            _ => println!("Unknown workflow command"),
-        },
-        Some(("sudo", sub_m)) => match sub_m.subcommand() {
-            Some(("delete-pin", sub_m)) => sudo_delete_pin(sub_m).await?,
-            Some(("delete-worker", sub_m)) => sudo_delete_worker(sub_m).await?,
-            Some(("delete-task", sub_m)) => sudo_delete_task(sub_m).await?,
-            Some(("freeze-account", sub_m)) => sudo_freeze_account(sub_m).await?,
-            _ => println!("Unknown sudo command"),
-        },
-        Some(("keygen", sub_m)) => generate_key(sub_m).await?,
-        Some(("compute-key", sub_m)) => compute_key(sub_m).await?,
-        Some(("send", sub_m)) => send_tokens(sub_m).await?,
-        Some(("account-info", sub_m)) => account_info(sub_m).await?,
-        Some(("generate-completion", sub_m)) => generate_completion(sub_m).await?,
-        Some(("build", sub_m)) => build(sub_m).await?,
-        _ => println!("Unknown command"),
-    }
-
-    Ok(())
-}
-
-/// Get gevulot-rs dependency version from cargo metadata.
-fn get_gevulot_rs_version(metadata: &Metadata) -> Option<String> {
-    const GEVULOT_RS_NAME: &str = "gevulot-rs";
-    let gvltctl = metadata.root_package()?;
-    let gevulot_rs_dep = gvltctl
-        .dependencies
-        .iter()
-        .find(|dep| &dep.name == GEVULOT_RS_NAME)?;
-
-    if let Some(path) = gevulot_rs_dep.path.as_ref() {
-        Some(format!(
-            "{} ({})",
-            metadata
-                .packages
-                .iter()
-                .find(|package| {
-                    &package.name == GEVULOT_RS_NAME && package.id.repr.starts_with("path")
-                })?
-                .version,
-            path.as_str()
-        ))
-    } else if gevulot_rs_dep
-        .source
-        .as_ref()
-        .is_some_and(|src| src.starts_with("git"))
-    {
-        metadata.packages.iter().find_map(|package| {
-            if &package.name == GEVULOT_RS_NAME {
-                package
-                    .id
-                    .repr
-                    .strip_prefix("git+")?
-                    .split('#')
-                    .collect::<Vec<_>>()
-                    .get(0)
-                    .map(|id| format!("{} ({})", package.version, id))
-            } else {
-                None
-            }
-        })
-    } else if gevulot_rs_dep
-        .source
-        .as_ref()
-        .is_some_and(|src| src.starts_with("registry"))
-    {
-        metadata.packages.iter().find_map(|package| {
-            if &package.name == GEVULOT_RS_NAME
-                && package
-                    .source
-                    .as_ref()
-                    .is_some_and(cargo_metadata::Source::is_crates_io)
-            {
-                Some(package.version.to_string())
-            } else {
-                None
-            }
-        })
-    } else {
-        return None;
-    }
-}
-
-/// Parses command-line arguments and returns the matches.
-///
-/// This function sets up the entire command-line interface structure,
-/// including all subcommands and their respective arguments.
-fn setup_command_line_args() -> Result<Command, Box<dyn std::error::Error>> {
-    let chain_args: [Arg; 6] = [
-        Arg::new("endpoint")
-            .short('e')
-            .long("endpoint")
-            .value_name("URL")
-            .env("GEVULOT_ENDPOINT")
-            .help("Sets the endpoint for the Gevulot client")
-            .value_hint(ValueHint::Url)
-            .action(ArgAction::Set),
-        Arg::new("gas_price")
-            .short('g')
-            .long("gas-price")
-            .value_name("PRICE")
-            .env("GEVULOT_GAS_PRICE")
-            .help("Sets the gas price for the Gevulot client")
-            .value_hint(ValueHint::Other)
-            .action(ArgAction::Set),
-        Arg::new("gas_multiplier")
-            .short('m')
-            .long("gas-multiplier")
-            .value_name("MULTIPLIER")
-            .env("GEVULOT_GAS_MULTIPLIER")
-            .help("Sets the gas multiplier for the Gevulot client")
-            .value_hint(ValueHint::Other)
-            .action(ArgAction::Set),
-        Arg::new("mnemonic")
-            .short('n')
-            .long("mnemonic")
-            .value_name("MNEMONIC")
-            .env("GEVULOT_MNEMONIC")
-            .help("Sets the mnemonic for the Gevulot client")
-            .value_hint(ValueHint::Other)
-            .action(ArgAction::Set),
-        Arg::new("password")
-            .short('p')
-            .long("password")
-            .value_name("PASSWORD")
-            .env("GEVULOT_PASSWORD")
-            .help("Sets the password for the Gevulot client")
-            .value_hint(ValueHint::Other)
-            .action(ArgAction::Set),
-        Arg::new("format")
-            .short('F')
-            .long("format")
-            .value_name("FORMAT")
-            .env("GEVULOT_FORMAT")
-            .help("Sets the output format (yaml, json, prettyjson, toml)")
-            .value_hint(ValueHint::Other)
-            .default_value("yaml")
-            .action(ArgAction::Set),
-    ];
-
-    let gevulot_rs_version =
-        serde_json::from_slice::<serde_json::Value>(&build_info::CARGO_METADATA)
-            .ok()
-            .map(Metadata::deserialize)
-            .map(Result::ok)
-            .flatten()
-            .as_ref()
-            .map(get_gevulot_rs_version)
-            .flatten();
-
-    let command = clap::command!()
-        .long_version(format!(
-            "{} ({})\ngevulot-rs {}\nplatform: {}",
-            build_info::PKG_VERSION,
-            if build_info::GIT_CLEAN {
-                format!(
-                    "{} {}",
-                    if build_info::TAG.is_empty() {
-                        build_info::SHORT_COMMIT
-                    } else {
-                        build_info::TAG
-                    },
-                    // Strip commit time and leave only date
-                    build_info::COMMIT_DATE.split(' ').collect::<Vec<_>>()[0],
-                )
-            } else {
-                format!("{}-dirty", build_info::SHORT_COMMIT)
-            },
-            gevulot_rs_version.unwrap_or_else(|| "unknown".to_string()),
-            build_info::BUILD_TARGET,
-        ))
-        .subcommand_required(true)
-        // Worker subcommand
-        .subcommand(
-            Command::new("worker")
-                .about("Commands related to workers")
-                .subcommand_required(true)
-                .subcommand(
-                    Command::new("list")
-                        .about("List all workers")
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("get")
-                        .about("Get a specific worker")
-                        .arg(
-                            Arg::new("id")
-                                .value_name("ID")
-                                .help("The ID of the worker to retrieve")
-                                .required(true)
-                                .index(1),
-                        )
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("create")
-                        .about("Create a new worker")
-                        .arg(
-                            Arg::new("file")
-                                .short('f')
-                                .long("file")
-                                .value_name("FILE")
-                                .value_hint(ValueHint::FilePath)
-                                .help("The file to read the worker data from, defaults to stdin")
-                                .action(ArgAction::Set),
-                        )
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("delete")
-                        .about("Delete a worker")
-                        .args(&chain_args),
-                ),
-        )
-        // Pin subcommand
-        .subcommand(
-            Command::new("pin")
-                .about("Commands related to pins")
-                .subcommand_required(true)
-                .subcommand(
-                    Command::new("list")
-                        .about("List all pins")
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("get")
-                        .about("Get a specific pin")
-                        .arg(
-                            Arg::new("cid")
-                                .value_name("CID")
-                                .help("The CID of the pin to retrieve")
-                                .value_hint(ValueHint::Other)
-                                .required(true)
-                                .index(1),
-                        )
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("ack")
-                        .about("Ack a pin")
-                        .arg(
-                            Arg::new("cid")
-                                .value_name("CID")
-                                .help("The CID of the pin to ack")
-                                .value_hint(ValueHint::Other)
-                                .required(true)
-                                .index(1),
-                        )
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("create")
-                        .about("Create a new pin")
-                        .arg(
-                            Arg::new("file")
-                                .short('f')
-                                .long("file")
-                                .value_name("FILE")
-                                .value_hint(ValueHint::FilePath)
-                                .help("The file to read the pin data from, defaults to stdin")
-                                .action(ArgAction::Set),
-                        )
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("delete")
-                        .about("Delete a pin")
-                        .args(&chain_args),
-                ),
-        )
-        // Task subcommand
-        .subcommand(
-            Command::new("task")
-                .about("Commands related to tasks")
-                .subcommand_required(true)
-                .subcommand(
-                    Command::new("list")
-                        .about("List all tasks")
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("get")
-                        .about("Get a specific task")
-                        .arg(
-                            Arg::new("id")
-                                .value_name("ID")
-                                .help("The ID of the task to retrieve")
-                                .value_hint(ValueHint::Other)
-                                .required(true)
-                                .index(1),
-                        )
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("create")
-                        .about("Create a new task")
-                        .arg(
-                            Arg::new("file")
-                                .short('f')
-                                .long("file")
-                                .value_name("FILE")
-                                .help("The file to read the task data from, defaults to stdin")
-                                .value_hint(ValueHint::FilePath)
-                                .action(ArgAction::Set),
-                        )
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("accept")
-                        .about("Accept a task (you probably should not use this)")
-                        .arg(
-                            Arg::new("id")
-                                .value_name("ID")
-                                .help("The ID of the task to accept")
-                                .required(true)
-                                .index(1),
-                        )
-                        .arg(
-                            Arg::new("worker_id")
-                                .value_name("WORKER_ID")
-                                .help("The ID of the worker accepting the task")
-                                .required(true)
-                                .index(2),
-                        )
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("decline")
-                        .about("Decline a task (you probably should not use this)")
-                        .arg(
-                            Arg::new("id")
-                                .value_name("ID")
-                                .help("The ID of the task to decline")
-                                .required(true)
-                                .index(1),
-                        )
-                        .arg(
-                            Arg::new("worker_id")
-                                .value_name("WORKER_ID")
-                                .help("The ID of the worker declining the task")
-                                .required(true)
-                                .index(2),
-                        )
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("finish")
-                        .about("Finish a task (you probably should not use this)")
-                        .arg(
-                            Arg::new("id")
-                                .value_name("ID")
-                                .help("The ID of the task to finish")
-                                .required(true)
-                                .index(1),
-                        )
-                        .arg(
-                            Arg::new("exit_code")
-                                .value_name("EXIT_CODE")
-                                .help("The exit code of the task")
-                                .value_parser(value_parser!(i32))
-                                .required(false),
-                        )
-                        .arg(
-                            Arg::new("stdout")
-                                .value_name("STDOUT")
-                                .help("The stdout output of the task")
-                                .required(false),
-                        )
-                        .arg(
-                            Arg::new("stderr")
-                                .value_name("STDERR")
-                                .help("The stderr output of the task")
-                                .required(false),
-                        )
-                        .arg(
-                            Arg::new("error")
-                                .value_name("ERROR")
-                                .help("Any error message from the task")
-                                .required(false),
-                        )
-                        .arg(
-                            Arg::new("output_contexts")
-                                .value_name("OUTPUT_CONTEXTS")
-                                .help("Output contexts produced by the task")
-                                .required(false)
-                                .action(ArgAction::Append),
-                        )
-                        .args(&chain_args),
-                ),
-        )
-        // Workflow subcommand
-        .subcommand(
-            Command::new("workflow")
-                .about("Commands related to workflows")
-                .subcommand_required(true)
-                .subcommand(
-                    Command::new("list")
-                        .about("List all workflows")
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("get")
-                        .about("Get a specific workflow")
-                        .arg(
-                            Arg::new("id")
-                                .value_name("ID")
-                                .help("The ID of the workflow to retrieve")
-                                .value_hint(ValueHint::Other)
-                                .required(true)
-                                .index(1),
-                        )
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("create")
-                        .about("Create a new workflow")
-                        .arg(
-                            Arg::new("file")
-                                .short('f')
-                                .long("file")
-                                .value_name("FILE")
-                                .help("The file to read the workflow data from, defaults to stdin")
-                                .value_hint(ValueHint::FilePath)
-                                .action(ArgAction::Set),
-                        )
-                        .args(&chain_args),
-                )
-                .subcommand(
-                    Command::new("delete")
-                        .about("Delete a workflow")
-                        .args(&chain_args),
-                ),
-        )
-        // Keygen subcommand
-        .subcommand(
-            Command::new("keygen")
-                .about("Generate a new key")
-                .arg(
-                    Arg::new("file")
-                        .short('f')
-                        .long("file")
-                        .value_name("FILE")
-                        .help("The file to write the seed to, defaults to stdout")
-                        .value_hint(ValueHint::FilePath)
-                        .action(ArgAction::Set),
-                )
-                .arg(
-                    Arg::new("password")
-                        .short('p')
-                        .long("password")
-                        .value_name("PASSWORD")
-                        .help("Sets the password for the Gevulot client")
-                        .value_hint(ValueHint::Other)
-                        .action(ArgAction::Set)
-                        .global(true),
-                )
-                .arg(
-                    Arg::new("format")
-                        .short('F')
-                        .long("format")
-                        .value_name("FORMAT")
-                        .default_value("yaml")
-                        .help("Sets the output format (yaml, json, prettyjson, toml)"),
-                ),
-        )
-        .subcommand(
-            Command::new("compute-key")
-                .about("Compute a key")
-                .arg(
-                    Arg::new("mnemonic")
-                        .long("mnemonic")
-                        .value_name("MNEMONIC")
-                        .env("GEVULOT_MNEMONIC")
-                        .help("The mnemonic to compute the key from")
-                        .required(true)
-                        .value_hint(ValueHint::Other),
-                )
-                .arg(
-                    Arg::new("password")
-                        .long("password")
-                        .value_name("PASSWORD")
-                        .env("GEVULOT_PASSWORD")
-                        .help("The password to compute the key with")
-                        .value_hint(ValueHint::Other),
-                )
-                .arg(
-                    Arg::new("format")
-                        .short('F')
-                        .long("format")
-                        .value_name("FORMAT")
-                        .default_value("yaml")
-                        .help("Sets the output format (yaml, json, prettyjson, toml"),
-                ),
-        )
-        // Send subcommand
-        .subcommand(
-            Command::new("send")
-                .about("Send tokens to a receiver on the Gevulot network")
-                .arg(
-                    Arg::new("amount")
-                        .value_name("AMOUNT")
-                        .help("The amount of tokens to send")
-                        .required(true)
-                        .index(1)
-                        .value_hint(ValueHint::Other),
-                )
-                .arg(
-                    Arg::new("receiver")
-                        .value_name("RECEIVER")
-                        .help("The receiver address")
-                        .required(true)
-                        .index(2)
-                        .value_hint(ValueHint::Other),
-                )
-                .args(&chain_args),
-        )
-        // Account-info subcommand
-        .subcommand(
-            Command::new("account-info")
-                .about("Get the balance of the given account")
-                .arg(
-                    Arg::new("address")
-                        .value_name("ADDRESS")
-                        .help("The address to get the balance of")
-                        .required(true)
-                        .index(1)
-                        .value_hint(ValueHint::Other),
-                )
-                .args(&chain_args),
-        )
-        .subcommand(
-            Command::new("generate-completion")
-                .about("Generate shell completion scripts")
-                .arg(
-                    Arg::new("shell")
-                        .value_name("SHELL")
-                        .help("The shell to generate the completion scripts for")
-                        .required(true)
-                        .action(ArgAction::Set)
-                        .value_parser(value_parser!(clap_complete::Shell))
-                        .index(1)
-                        .value_hint(ValueHint::Other),
-                )
-                .arg(
-                    Arg::new("file")
-                        .short('f')
-                        .long("file")
-                        .value_name("FILE")
-                        .help("The file to write the completion scripts to, defaults to stdout")
-                        .action(ArgAction::Set)
-                        .value_hint(ValueHint::FilePath),
-                ),
-        )
-        .subcommand(commands::sudo::get_command(&chain_args))
-        .subcommand(commands::build::get_command());
-
-    Ok(command)
-}
-
-/// Connects to the Gevulot network using the provided command-line arguments.
-///
-/// This function creates a GevulotClient based on the endpoint, gas price,
-/// gas multiplier, and mnemonic provided in the command-line arguments.
-///
-/// # Arguments
-///
-/// * `matches` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///
-/// # Returns
-///
-/// A Result containing a GevulotClient if successful, or a Box<dyn std::error::Error> if an error occurs.
-async fn connect_to_gevulot(
-    matches: &clap::ArgMatches,
-) -> Result<GevulotClient, Box<dyn std::error::Error>> {
-    let mut client_builder = GevulotClientBuilder::default();
-
-    // Set the endpoint if provided
-    if let Some(endpoint) = matches.get_one::<String>("endpoint") {
-        client_builder = client_builder.endpoint(endpoint);
-    }
-
-    // Set the gas price if provided
-    if let Some(gas_price) = matches.get_one::<String>("gas_price") {
-        client_builder = client_builder.gas_price(
-            gas_price
-                .parse()
-                .map_err(|e| format!("Failed to parse gas_price: {}", e))?,
-        );
-    }
-
-    // Set the gas multiplier if provided
-    if let Some(gas_multiplier) = matches.get_one::<String>("gas_multiplier") {
-        client_builder = client_builder.gas_multiplier(
-            gas_multiplier
-                .parse()
-                .map_err(|e| format!("Failed to parse gas_multiplier: {}", e))?,
-        );
-    }
-
-    // Set the mnemonic if provided
-    if let Some(mnemonic) = matches.get_one::<String>("mnemonic") {
-        client_builder = client_builder.mnemonic(mnemonic);
-    }
-
-    // Set the password if provided
-    if let Some(password) = matches.get_one::<String>("password") {
-        client_builder = client_builder.password(password);
-    }
-
-    // Build and return the client
-    let client = client_builder.build().await?;
-
-    Ok(client)
-}
-
-/// Reads and parses a file or stdin input into a specified type.
-///
-/// This function is generic over T, which must implement DeserializeOwned.
-/// It reads from a file if specified in the command-line arguments,
-/// otherwise it reads from stdin.
-///
-/// # Arguments
-///
-/// * `matches` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///
-/// # Returns
-///
-/// A Result containing the parsed value of type T if successful, or a Box<dyn std::error::Error> if an error occurs.
-async fn read_file<T: DeserializeOwned>(
-    matches: &clap::ArgMatches,
-) -> Result<T, Box<dyn std::error::Error>> {
-    let content = match matches.get_one::<String>("file") {
-        Some(file) => {
-            let mut file = File::open(file)?;
-            let mut contents = String::new();
-            file.read_to_string(&mut contents)?;
-            contents
-        }
-        None => {
-            let mut contents = String::new();
-            io::stdin().read_to_string(&mut contents)?;
-            contents
-        }
-    };
-    let parsed: T = serde_yaml::from_str(&content)?;
-    Ok(parsed)
-}
-
-/// Prints an object in the specified format.
-///
-/// This function takes a reference to command-line arguments and a serializable value,
-/// and prints the value in the format specified by the user (yaml, json, prettyjson, or toml).
-///
-/// # Arguments
-///
-/// * `matches` - A reference to the ArgMatches struct containing parsed command-line arguments.
-/// * `value` - A reference to the value to be printed, which must implement Serialize.
-///
-/// # Returns
-///
-/// A Result indicating success or an error if serialization or printing fails.
-fn print_object<T: Serialize>(
-    matches: &clap::ArgMatches,
-    value: &T,
-) -> Result<(), Box<dyn std::error::Error>> {
-    // Get the format from command-line arguments, defaulting to "yaml" if not specified
-    let format = matches
-        .get_one::<String>("format")
-        .expect("format has a default value");
-
-    // Match on the format string and serialize/print accordingly
-    match format.as_str() {
-        "yaml" => {
-            // Serialize to YAML and print
-            let yaml = serde_yaml::to_string(value)?;
-            println!("{}", yaml);
-        }
-        "json" => {
-            // Serialize to compact JSON and print
-            let json = serde_json::to_string(value)?;
-            println!("{}", json);
-        }
-        "prettyjson" => {
-            // Serialize to pretty-printed JSON and print
-            let prettyjson = serde_json::to_string_pretty(value)?;
-            println!("{}", prettyjson);
-        }
-        "toml" => {
-            // Serialize to TOML and print
-            let toml = toml::to_string(value)?;
-            println!("{}", toml);
-        }
-        // If an unknown format is specified, print an error message
-        _ => println!("Unknown format"),
-    }
-
-    Ok(())
+    Cli::parse().run().await
 }
 
 /// Sends tokens to a receiver on the Gevulot network.
-///
-/// # Arguments
-///
-/// * `sub_m` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///
-/// # Returns
-///
-/// A Result indicating success or an error if the token transfer fails.
-async fn send_tokens(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let client = connect_to_gevulot(_sub_m).await?;
-    let amount = _sub_m.get_one::<String>("amount").unwrap();
-    let receiver = _sub_m.get_one::<String>("receiver").unwrap();
+async fn send_tokens(
+    chain_args: &ChainArgs,
+    amount: u128,
+    receiver: &str,
+    format: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let client = connect_to_gevulot(chain_args).await?;
     client
         .base_client
         .write()
         .await
-        .token_transfer(receiver, amount.parse()?)
+        .token_transfer(receiver, amount)
         .await?;
 
     let output = serde_json::json!({
@@ -787,23 +172,18 @@ async fn send_tokens(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error
         "receiver": receiver
     });
 
-    print_object(_sub_m, &output)?;
+    print_object(format, &output)?;
 
     Ok(())
 }
 
 /// Retrieves and displays account information for a given address.
-///
-/// # Arguments
-///
-/// * `sub_m` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///https://github.com/gevulotnetwork/platform/pull/60
-/// # Returns
-///
-/// A Result indicating success or an error if the account information retrieval fails.
-async fn account_info(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let client = connect_to_gevulot(_sub_m).await?;
-    let address = _sub_m.get_one::<String>("address").unwrap();
+async fn account_info(
+    chain_args: &ChainArgs,
+    address: &str,
+    format: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let client = connect_to_gevulot(chain_args).await?;
     let account = client
         .base_client
         .write()
@@ -823,21 +203,21 @@ async fn account_info(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::erro
         "balance": balance.amount.to_string()
     });
 
-    print_object(_sub_m, &output)?;
+    print_object(format, &output)?;
     Ok(())
 }
 
 /// Generates a new key and optionally saves it to a file.
-async fn generate_key(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
+async fn generate_key(
+    path: Option<&PathBuf>,
+    password: &str,
+    format: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Generate random Mnemonic using the default language (English)
     let mnemonic = Mnemonic::random(OsRng, Default::default());
-    let password = _sub_m
-        .get_one::<String>("password")
-        .cloned()
-        .unwrap_or("".to_string());
 
     // Derive a BIP39 seed value using the given password
-    let seed = mnemonic.to_seed(&password);
+    let seed = mnemonic.to_seed(password);
 
     // Derive a child `XPrv` using the provided BIP32 derivation path
     let child_path = "m/44'/118'/0'/0/0";
@@ -865,51 +245,26 @@ async fn generate_key(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::erro
         "mnemonic": phrase
     });
 
-    if let Some(file) = _sub_m.get_one::<String>("file") {
+    if let Some(file) = path {
         let mut file = File::create(file)?;
         file.write_all(phrase.as_bytes())?;
     }
 
-    match _sub_m.get_one::<String>("format").map(String::as_str) {
-        Some("json") => {
-            let json = serde_json::to_string(&output)?;
-            println!("{}", json);
-        }
-        Some("prettyjson") => {
-            let prettyjson = serde_json::to_string_pretty(&output)?;
-            println!("{}", prettyjson);
-        }
-        Some("toml") => {
-            let toml = toml::to_string(&output)?;
-            println!("{}", toml);
-        }
-        Some("yaml") => {
-            let yaml = serde_yaml::to_string(&output)?;
-            println!("{}", yaml);
-        }
-        _ => {
-            println!("{}", account_id);
-            println!("{}", phrase);
-        }
-    }
+    print_object(format, &output)?;
 
     Ok(())
 }
 
 /// Generates a new key and optionally saves it to a file.
-async fn compute_key(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let mnemonic = Mnemonic::new(
-        _sub_m.get_one::<String>("mnemonic").unwrap(),
-        bip32::Language::English,
-    )?;
-
-    let password = _sub_m
-        .get_one::<String>("password")
-        .cloned()
-        .unwrap_or("".to_string());
+async fn compute_key(
+    mnemonic: &str,
+    password: &str,
+    format: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mnemonic = Mnemonic::new(mnemonic, bip32::Language::English)?;
 
     // Derive a BIP39 seed value using the given password
-    let seed = mnemonic.to_seed(&password);
+    let seed = mnemonic.to_seed(password);
 
     // Derive a child `XPrv` using the provided BIP32 derivation path
     let child_path = "m/44'/118'/0'/0/0";
@@ -932,57 +287,22 @@ async fn compute_key(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error
     let account_id = sk.public_key().account_id("gvlt").unwrap();
 
     let output = serde_json::json!({ "account_id": account_id });
-    print_object(_sub_m, &output)?;
+    print_object(format, &output)?;
     Ok(())
 }
 
 /// Generates shell completion scripts for the gvltctl command-line tool.
-///
-/// This function generates shell completion scripts for the gvltctl command-line tool
-/// and prints the results to the console.
-///
-/// # Arguments
-///
-/// * `sub_m` - A reference to the ArgMatches struct containing parsed command-line arguments.
-///
-/// # Returns
-///
-/// A Result indicating success or an error if the completion generation fails.
-async fn generate_completion(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    if let Some(generator) = _sub_m.get_one::<Shell>("shell").copied() {
-        let mut cmd = setup_command_line_args()?; // Assuming you have a Command::new() function
-        eprintln!("Generating completion file for {generator}...");
-        if let Some(file) = _sub_m.get_one::<String>("file") {
-            let mut file = File::create(file)?;
-            generate(generator, &mut cmd, "gvltctl", &mut file);
-        } else {
-            generate(generator, &mut cmd, "gvltctl", &mut io::stdout());
-        }
+async fn generate_completion(
+    shell: Shell,
+    path: Option<&PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    eprintln!("Generating completion file for {shell}...");
+    let mut cmd = Cli::command();
+    if let Some(file) = path {
+        let mut file = File::create(file)?;
+        clap_complete::generate(shell, &mut cmd, "gvltctl", &mut file);
     } else {
-        eprintln!("No shell specified for completion generation");
+        clap_complete::generate(shell, &mut cmd, "gvltctl", &mut io::stdout());
     }
     Ok(())
-}
-async fn list_workflows(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    let output = serde_json::json!({
-        "message": "Listing all workflows",
-        "status": "not_implemented"
-    });
-    print_object(_sub_m, &output)?;
-    todo!();
-}
-
-async fn get_workflow(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Getting a specific workflow");
-    todo!();
-}
-
-async fn create_workflow(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Creating a new workflow");
-    todo!();
-}
-
-async fn delete_workflow(_sub_m: &clap::ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
-    println!("Deleting a workflow");
-    todo!();
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,165 @@
+//! Common gevulot utilities.
+
+use clap::ValueEnum as _;
+use gevulot_rs::gevulot_client::GevulotClientBuilder;
+use gevulot_rs::GevulotClient;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::fmt;
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::Path;
+
+use crate::commands::ChainArgs;
+
+/// Connects to the Gevulot network using the provided command-line arguments.
+///
+/// This function creates a GevulotClient based on the endpoint, gas price,
+/// gas multiplier, and mnemonic provided in the command-line arguments.
+///
+/// # Arguments
+///
+/// * `matches` - A reference to the ArgMatches struct containing parsed command-line arguments.
+///
+/// # Returns
+///
+/// A Result containing a GevulotClient if successful, or a Box<dyn std::error::Error> if an error occurs.
+pub async fn connect_to_gevulot(
+    chain_args: &ChainArgs,
+) -> Result<GevulotClient, Box<dyn std::error::Error>> {
+    let mut client_builder = GevulotClientBuilder::default();
+
+    // Set the endpoint if provided
+    if let Some(endpoint) = &chain_args.endpoint {
+        client_builder = client_builder.endpoint(endpoint);
+    }
+
+    // Set the gas price if provided
+    if let Some(gas_price) = chain_args.gas_price {
+        client_builder = client_builder.gas_price(gas_price);
+    }
+
+    // Set the gas multiplier if provided
+    if let Some(gas_multiplier) = chain_args.gas_multiplier {
+        client_builder = client_builder.gas_multiplier(gas_multiplier);
+    }
+
+    // Set the mnemonic if provided
+    if let Some(mnemonic) = &chain_args.mnemonic {
+        client_builder = client_builder.mnemonic(mnemonic);
+    }
+
+    // Set the password if provided
+    if let Some(password) = &chain_args.password {
+        client_builder = client_builder.password(password);
+    }
+
+    // Build and return the client
+    let client = client_builder.build().await?;
+
+    Ok(client)
+}
+
+/// Reads and parses a file or stdin input into a specified type.
+///
+/// This function is generic over T, which must implement DeserializeOwned.
+/// It reads from a file if specified in the command-line arguments,
+/// otherwise it reads from stdin.
+///
+/// # Arguments
+///
+/// * `matches` - A reference to the ArgMatches struct containing parsed command-line arguments.
+///
+/// # Returns
+///
+/// A Result containing the parsed value of type T if successful, or a Box<dyn std::error::Error> if an error occurs.
+pub async fn read_file<T: DeserializeOwned>(
+    path: Option<&Path>,
+) -> Result<T, Box<dyn std::error::Error>> {
+    let content = match path {
+        Some(file) => {
+            let mut file = File::open(file)?;
+            let mut contents = String::new();
+            file.read_to_string(&mut contents)?;
+            contents
+        }
+        None => {
+            let mut contents = String::new();
+            io::stdin().read_to_string(&mut contents)?;
+            contents
+        }
+    };
+    let parsed: T = serde_yaml::from_str(&content)?;
+    Ok(parsed)
+}
+
+/// Possible output formats for Gevulot Control.
+#[derive(Copy, Clone, Debug, PartialEq, clap::ValueEnum)]
+#[value(rename_all = "lower")]
+pub enum OutputFormat {
+    Yaml,
+    Json,
+    PrettyJson,
+    Toml,
+}
+
+impl Default for OutputFormat {
+    fn default() -> Self {
+        Self::Yaml
+    }
+}
+
+impl fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.to_possible_value()
+                .expect("no skipped values")
+                .get_name()
+        )
+    }
+}
+
+/// Prints an object in the specified format.
+///
+/// This function takes a reference to command-line arguments and a serializable value,
+/// and prints the value in the format specified by the user (yaml, json, prettyjson, or toml).
+///
+/// # Arguments
+///
+/// * `matches` - A reference to the ArgMatches struct containing parsed command-line arguments.
+/// * `value` - A reference to the value to be printed, which must implement Serialize.
+///
+/// # Returns
+///
+/// A Result indicating success or an error if serialization or printing fails.
+pub fn print_object<T: Serialize>(
+    format: OutputFormat,
+    value: &T,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Match on the format string and serialize/print accordingly
+    match format {
+        OutputFormat::Yaml => {
+            // Serialize to YAML and print
+            let yaml = serde_yaml::to_string(value)?;
+            println!("{}", yaml);
+        }
+        OutputFormat::Json => {
+            // Serialize to compact JSON and print
+            let json = serde_json::to_string(value)?;
+            println!("{}", json);
+        }
+        OutputFormat::PrettyJson => {
+            // Serialize to pretty-printed JSON and print
+            let prettyjson = serde_json::to_string_pretty(value)?;
+            println!("{}", prettyjson);
+        }
+        OutputFormat::Toml => {
+            // Serialize to TOML and print
+            let toml = toml::to_string(value)?;
+            println!("{}", toml);
+        }
+    }
+    Ok(())
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,106 @@
+//! Version calculation utilities.
+
+use cargo_metadata::Metadata;
+use serde::Deserialize;
+
+shadow_rs::shadow!(build_info);
+
+/// Get gevulot-rs dependency version from cargo metadata.
+fn get_gevulot_rs_version(metadata: &Metadata) -> Option<String> {
+    const GEVULOT_RS_NAME: &str = "gevulot-rs";
+    let gvltctl = metadata.root_package()?;
+    let gevulot_rs_dep = gvltctl
+        .dependencies
+        .iter()
+        .find(|dep| dep.name == GEVULOT_RS_NAME)?;
+
+    if let Some(path) = gevulot_rs_dep.path.as_ref() {
+        Some(format!(
+            "{} ({})",
+            metadata
+                .packages
+                .iter()
+                .find(|package| {
+                    package.name == GEVULOT_RS_NAME && package.id.repr.starts_with("path")
+                })?
+                .version,
+            path.as_str()
+        ))
+    } else if gevulot_rs_dep
+        .source
+        .as_ref()
+        .is_some_and(|src| src.starts_with("git"))
+    {
+        metadata.packages.iter().find_map(|package| {
+            if package.name == GEVULOT_RS_NAME {
+                package
+                    .id
+                    .repr
+                    .strip_prefix("git+")?
+                    .split('#')
+                    .collect::<Vec<_>>()
+                    .first()
+                    .map(|id| format!("{} ({})", package.version, id))
+            } else {
+                None
+            }
+        })
+    } else if gevulot_rs_dep
+        .source
+        .as_ref()
+        .is_some_and(|src| src.starts_with("registry"))
+    {
+        metadata.packages.iter().find_map(|package| {
+            if package.name == GEVULOT_RS_NAME
+                && package
+                    .source
+                    .as_ref()
+                    .is_some_and(cargo_metadata::Source::is_crates_io)
+            {
+                Some(package.version.to_string())
+            } else {
+                None
+            }
+        })
+    } else {
+        return None;
+    }
+}
+
+/// Get long version of the tool.
+///
+/// This includes:
+/// - package version
+/// - git info
+/// - gevulot-rs version
+/// - platform info
+#[allow(clippy::const_is_empty)]
+pub fn get_long_version() -> String {
+    let gevulot_rs_version =
+        serde_json::from_slice::<serde_json::Value>(build_info::CARGO_METADATA)
+            .ok()
+            .map(Metadata::deserialize)
+            .and_then(Result::ok)
+            .as_ref()
+            .and_then(get_gevulot_rs_version);
+    format!(
+        "{} ({})\ngevulot-rs {}\nplatform: {}",
+        build_info::PKG_VERSION,
+        if build_info::GIT_CLEAN {
+            format!(
+                "{} {}",
+                if build_info::TAG.is_empty() {
+                    build_info::SHORT_COMMIT
+                } else {
+                    build_info::TAG
+                },
+                // Strip commit time and leave only date
+                build_info::COMMIT_DATE.split(' ').collect::<Vec<_>>()[0],
+            )
+        } else {
+            format!("{}-dirty", build_info::SHORT_COMMIT)
+        },
+        gevulot_rs_version.unwrap_or_else(|| "unknown".to_string()),
+        build_info::BUILD_TARGET,
+    )
+}


### PR DESCRIPTION
This PR replaces imperative `clap` Builder approach (with `clap::Command`) with more declarative `clap` Derive approach.

The actual CLI **stays exactly the same** (apart from some fixes in it). Only the internal implementation changed.

## Motivation

Essentially this helps handling CLI args and avoids getting from `clap::ArgMatches` during actual function calls. So we no longer have to report manually errors like `error: ID is required`.

## Changes

- A lot of code refactored
- Fixed a number of bugs with missing arguments: some commands were expecting arguments, which weren't defined for that `clap::Command` at all - so they were constantly panicing.
- Made `-F/--format` option global, so it is now inherited by any sub-command (however `gvltctl build` doesn't respect this option).
- Improved readability of `gvltctl build -h/--help` - now works better in terms of short and long help.
- `--no-gevulot-runtime` and `--rw-root` options of `gvltctl build` were hidden from help (they are intended only for debug purposes).
- Hide `GEVULOT_MNEMONIC` and `GEVULOT_PASSWORD` env variables from `--help` output.

## Further work

- Simplify args handling in `gvltctl build`: now two almost identical structures are used. This was done to ensure stability of builder behavior.

_(I couldn't find a way to split this PR into a number of different meaningful commits, sorry)_