### PR TITLE
Remove Linux OS gate for build subcommand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,8 @@ tokio = { version = "1", features = ["full"] }
 toml = "0.8.19"
 openssl = { version = "*", optional = true }
 
-[build-dependencies]
-shadow-rs = { version = "0.36", features = ["metadata"] }
-
-[features]
-# This feature should be enabled when building static executable
-openssl-vendored = ["openssl/vendored"]
-
-[target.'cfg(target_os = "linux")'.dependencies]
-mia-installer = { git = "https://github.com/gevulotnetwork/mia.git", tag = "mia-installer-0.2.5"}
+# Linux VM builder dependencies
+mia-installer = { git = "https://github.com/gevulotnetwork/mia.git", tag = "mia-installer-0.2.5" }
 
 anyhow = "1"
 log = "0.4.22"
@@ -41,3 +34,10 @@ num_cpus = "1.16.0"
 oci-spec = "0.7.0"
 tempdir = "0.3.7"
 thiserror = "1"
+
+[build-dependencies]
+shadow-rs = { version = "0.36", features = ["metadata"] }
+
+[features]
+# This feature should be enabled when building static executable
+openssl-vendored = ["openssl/vendored"]

--- a/README.md
+++ b/README.md
@@ -73,3 +73,9 @@ Options:
   -h, --help     Print help
   -V, --version  Print version
 ```
+
+## Supported platforms
+
+`gvltctl` is supported on both Linux and MacOS (Windows is not tested, but probably also works).
+
+Building Linux VM (`gvltctl build`) is only supported on Linux right now.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(target_os = "linux")]
 pub mod build;
 pub mod pins;
 pub mod tasks;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,9 @@ use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{self, Read, Write};
 
-#[cfg(target_os = "linux")]
 mod builders;
 mod commands;
 
-#[cfg(target_os = "linux")]
 use commands::build::*;
 use commands::{pins::*, sudo::*, tasks::*, workers::*};
 
@@ -78,7 +76,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(("send", sub_m)) => send_tokens(sub_m).await?,
         Some(("account-info", sub_m)) => account_info(sub_m).await?,
         Some(("generate-completion", sub_m)) => generate_completion(sub_m).await?,
-        #[cfg(target_os = "linux")]
         Some(("build", sub_m)) => build(sub_m).await?,
         _ => println!("Unknown command"),
     }
@@ -215,8 +212,7 @@ fn setup_command_line_args() -> Result<Command, Box<dyn std::error::Error>> {
             .map(get_gevulot_rs_version)
             .flatten();
 
-    #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
-    let mut command = clap::command!()
+    let command = clap::command!()
         .long_version(format!(
             "{} ({})\ngevulot-rs {}\nplatform: {}",
             build_info::PKG_VERSION,
@@ -619,12 +615,8 @@ fn setup_command_line_args() -> Result<Command, Box<dyn std::error::Error>> {
                         .value_hint(ValueHint::FilePath),
                 ),
         )
-        .subcommand(commands::sudo::get_command(&chain_args));
-
-    #[cfg(target_os = "linux")]
-    {
-        command = command.subcommand(commands::build::get_command());
-    }
+        .subcommand(commands::sudo::get_command(&chain_args))
+        .subcommand(commands::build::get_command());
 
     Ok(command)
 }


### PR DESCRIPTION
This PR removes Linux OS gate from `build` subcommand. So MacOS builds will have this subcommand compiled.

`build` subcommand is now successfully builds (all MIA-related issues are gone).

However building VM is still not supported on MacOS. Instead of gating it and getting different subcommand set on different platforms, we would rather document supported systems in docs.