### PR TITLE
Clear build warnings

### DIFF
--- a/src/builders_v2/linux_vm/filesystem/ext4_linux.rs
+++ b/src/builders_v2/linux_vm/filesystem/ext4_linux.rs
@@ -15,9 +15,11 @@ use crate::builders::Step;
 /// EXT4 filesystem adapter on Linux.
 pub struct Ext4<'a> {
     /// Path to image file.
+    #[allow(unused)]
     path: &'a Path,
 
     /// Partition start offset in bytes.
+    #[allow(unused)]
     offset: u64,
 }
 
@@ -32,6 +34,7 @@ impl<'a> Ext4<'a> {
             + (value % Self::BLOCK_SIZE != 0) as u64 * Self::BLOCK_SIZE
     }
 
+    #[allow(unused)]
     pub fn new(path: &'a Path, start: u64, _end: u64) -> Self {
         Self {
             path,
@@ -39,10 +42,12 @@ impl<'a> Ext4<'a> {
         }
     }
 
+    #[allow(unused)]
     pub fn offset(&self) -> u64 {
         self.offset
     }
 
+    #[allow(unused)]
     pub fn path(&self) -> &'a Path {
         self.path
     }
@@ -86,6 +91,7 @@ impl<'a> Ext4<'a> {
     /// Run filesystem check.
     ///
     /// Wrapper for `e2fsck -f -n IMAGE?offset=OFFSET`
+    #[allow(unused)]
     pub fn check(&self) -> Result<()> {
         let mut target = self.path.as_os_str().to_os_string();
         target.push(OsStr::new(&format!("?offset={}", self.offset)));
@@ -104,6 +110,7 @@ impl<'a> Ext4<'a> {
     /// `new_size` - new size of the filesystem in blocks.
     ///
     /// Wrapper for `resize2fs`.
+    #[allow(unused)]
     pub fn resize(&self, new_size: u64) -> Result<()> {
         // HACK: becase resize2fs IMAGE?offset=OFFSET produces broken filesystem,
         // we copy the filesystem into temp file, temporarily stripping pre-fs sectors,

--- a/src/builders_v2/linux_vm/filesystem/fat32.rs
+++ b/src/builders_v2/linux_vm/filesystem/fat32.rs
@@ -58,6 +58,7 @@ impl<'a> Fat32<'a> {
     }
 
     /// Path to image file.
+    #[allow(unused)]
     pub fn path(&self) -> &'a Path {
         self.path
     }
@@ -68,6 +69,7 @@ impl<'a> Fat32<'a> {
     }
 
     /// Exclusive offset of the filesystem in disk image.
+    #[allow(unused)]
     pub fn end(&self) -> u64 {
         self.end
     }

--- a/src/builders_v2/linux_vm/filesystem/squashfs.rs
+++ b/src/builders_v2/linux_vm/filesystem/squashfs.rs
@@ -28,6 +28,7 @@ impl<'a, 'b, 'c> SquashFs<'a, 'b, 'c> {
     }
 
     /// Reference to filesystem writer.
+    #[allow(unused)]
     pub fn fs_writer(&self) -> &FilesystemWriter<'a, 'b, 'c> {
         &self.fs_writer
     }

--- a/src/builders_v2/linux_vm/image_file.rs
+++ b/src/builders_v2/linux_vm/image_file.rs
@@ -112,6 +112,7 @@ impl ImageFile {
     }
 
     /// Delete image file.
+    #[allow(unused)]
     pub fn delete(self) -> Result<()> {
         fs::remove_file(self.path).map_err(Into::into)
     }

--- a/src/builders_v2/linux_vm/kernel.rs
+++ b/src/builders_v2/linux_vm/kernel.rs
@@ -28,9 +28,11 @@ pub enum Kernel {
     /// Kernel compiled from sources.
     Sources {
         /// URL used to fetch source code.
+        #[allow(unused)]
         git_url: String,
 
         /// Git version to checkout (e.g. `v6.10.11`).
+        #[allow(unused)]
         version: String,
 
         /// Path to sources.
@@ -87,6 +89,7 @@ impl Kernel {
     // TODO: use this function.
     // TODO: maybe use libgit instead of executable?
     /// Clone Linux kernel repository into `path/version` returning path to resulting directory.
+    #[allow(unused)]
     fn clone(git_url: &str, version: &str, path: &Path) -> Result<PathBuf> {
         let target_path = path.join(version);
         let mut command = vec![

--- a/src/builders_v2/linux_vm/mount/mod.rs
+++ b/src/builders_v2/linux_vm/mount/mod.rs
@@ -18,6 +18,7 @@ pub trait MountHandler: Sized {
     fn unmount_no_drop(&self) -> Result<()>;
 
     /// Remove mount destroying `self`.
+    #[allow(unused)]
     fn unmount(self) -> Result<()> {
         self.unmount_no_drop()
     }


### PR DESCRIPTION
Just clear dead code warnings.

This code seems useful in the future, so I don't want to just remove it. Also this may be useful if at some point we would like to expose builder as a library: building VM images with Rust API may be useful for testing e.g.