### PR TITLE
Fix "Too many open files" error with SquashFS

### DIFF
--- a/src/builders_v2/linux_vm/mod.rs
+++ b/src/builders_v2/linux_vm/mod.rs
@@ -279,6 +279,7 @@ impl LinuxVMBuildContext {
 
     /// Pop value from context by key. `T` is a downcast type of value.
     /// Returns `None` if `key` doesn't exists or downcast type is wrong.
+    #[allow(unused)]
     pub fn pop<T>(&mut self, key: &'static str) -> Option<Box<T>>
     where
         T: 'static,
@@ -403,7 +404,7 @@ fn setup_pipeline(ctx: &mut LinuxVMBuildContext) -> Pipeline<LinuxVMBuildContext
 
     match &ctx.opts().root_fs_opts {
         RootFsOpts::SquashFs => {
-            steps.push(Box::new(filesystem::squashfs::Init));
+            steps.push(Box::new(filesystem::squashfs::Format));
             steps.push(Box::new(rootfs::InstallToSquashFs));
             steps.push(Box::new(filesystem::squashfs::EvaluateSize));
         }

--- a/src/builders_v2/linux_vm/rootfs.rs
+++ b/src/builders_v2/linux_vm/rootfs.rs
@@ -108,8 +108,10 @@ impl Step<LinuxVMBuildContext> for InstallToSquashFs {
     fn run(&mut self, ctx: &mut LinuxVMBuildContext) -> Result<()> {
         info!("writing root filesystem to SquashFS");
         let rootfs = ctx.get::<PathBuf>("root-fs").expect("root-fs").to_owned();
-        let squashfs = ctx.get_mut::<SquashFs>("squashfs").expect("squashfs");
-        squashfs.push_dir_recursively(&rootfs)?;
+        let squashfs = SquashFs::get(ctx.get_mut::<PathBuf>("squashfs").expect("squashfs"));
+        squashfs
+            .push_dir_recursively(&rootfs)
+            .context("failed to write root filesystem to SquashFS")?;
         Ok(())
     }
 }


### PR DESCRIPTION
# Changes

SquashFS is now written into a file every single time some modification is required. This way no open files are stored: we open source file, write new version of SquashFS with it and immediately close it. Next time it is extracted and re-written again. Compression is disabled to increase performance at least somehow and re-enabled at the end for the final image, before writing it into VM partition.

# Note

These changes create **SERIOUS PERFORMANCE ISSUES**. Re-writing SquashFS every time results in a dramatic increase in VM build time. E.g. before that it took about 4 seconds to build test image. Now it takes about 8 seconds. Building RISC0 image literally **takes ages**: I wasn't even able to wait till it ends.

I absolutely hate this solution.