### PR TITLE
Implement LazyReader for SquashFS writing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,6 +1311,7 @@ dependencies = [
  "log",
  "mbrman",
  "mia-installer",
+ "minilsof",
  "num_cpus",
  "oci-spec",
  "openssl",
@@ -1924,6 +1931,15 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minilsof"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c44fadc807092f5d438e690484378175d1beeb900d2f3048ab965d82d00c38"
+dependencies = [
+ "glob",
+]
 
 [[package]]
 name = "miniz_oxide"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,6 @@ vm-builder-v2 = [
 
 [patch.crates-io]
 gevulot-rs = { git = "https://github.com/gevulotnetwork/gevulot-rs", rev = "9aad7a9cbea15e9007ff5b45a566212bdf853620" }
+
+[dev-dependencies]
+minilsof = "0.1"

--- a/README.md
+++ b/README.md
@@ -107,5 +107,3 @@ Options:
 ## Supported platforms
 
 `gvltctl` is supported on both Linux and MacOS (Windows is not tested, but probably also works).
-
-Building Linux VM (`gvltctl build`) is only supported on Linux right now.


### PR DESCRIPTION
# Changes

SquashFS now stores `LazyOpen` instead of `std::fs::File` for each source file. Thus source file will be opened only on `read()` and there will be no file descriptor exhaustion.

# Note

There is no performance affect as far as I can tell.