### PR TITLE
Fix `gevulot-rs` version printing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,20 +404,6 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 1.0.64",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
@@ -537,12 +523,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const_fn"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
 name = "const_format"
@@ -1320,9 +1300,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
@@ -1369,7 +1349,6 @@ dependencies = [
  "base64 0.22.1",
  "bip32",
  "bytesize",
- "cargo_metadata 0.19.1",
  "clap 4.5.20",
  "clap_complete",
  "cosmrs",
@@ -1811,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "is_debug"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ea828c9d6638a5bd3d8b14e37502b4d56cae910ccf8a5b7f51c7a0eb1d0508"
+checksum = "1fe266d2e243c931d8190177f20bf7f24eed45e96f39e87dc49a27b32d12d407"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1904,9 +1883,9 @@ checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.17.0+1.8.1"
+version = "0.18.0+1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
 dependencies = [
  "cc",
  "libc",
@@ -3204,11 +3183,11 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.36.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2f59f8b166e94269530e0f47323c8b2a5b2d82ef90363cc7ce1e517e063f78"
+checksum = "3672eb035a31ac62bf171765d04e3f1f01659920847384d08ac979ca6bb56763"
 dependencies = [
- "cargo_metadata 0.18.1",
+ "cargo_metadata",
  "const_format",
  "git2",
  "is_debug",
@@ -3986,18 +3965,15 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "tz-rs"
-version = "0.6.14"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
-dependencies = [
- "const_fn",
-]
+checksum = "e1450bf2b99397e72070e7935c89facaa80092ac812502200375f1f7d33c71a1"
 
 [[package]]
 name = "tzdb"
-version = "0.6.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b580f6b365fa89f5767cdb619a55d534d04a4e14c2d7e5b9a31e94598687fb1"
+checksum = "0be2ea5956f295449f47c0b825c5e109022ff1a6a53bb4f77682a87c2341fbf5"
 dependencies = [
  "iana-time-zone",
  "tz-rs",
@@ -4006,9 +3982,9 @@ dependencies = [
 
 [[package]]
 name = "tzdb_data"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654c1ec546942ce0594e8d220e6b8e3899e0a0a8fe70ddd54d32a376dfefe3f8"
+checksum = "0604b35c1f390a774fdb138cac75a99981078895d24bcab175987440bbff803b"
 dependencies = [
  "tz-rs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ description = "Gevulot Control CLI"
 gevulot-rs = "0.3.0"
 
 bip32 = "0.5.1"
-cargo_metadata = "0.19"
 clap = { version = "4", features = ["derive", "env", "string"] }
 clap_complete = "4.5.13"
 cosmrs = "0.20"
@@ -19,7 +18,7 @@ downloader = "0.2"
 env_logger = "0.11.5"
 patharg = "0.4"
 rand_core = "0.6.4"
-shadow-rs = { version = "0.36", features = ["metadata"] }
+shadow-rs = { version = "1", features = ["metadata"] }
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.9.34"
@@ -56,7 +55,7 @@ mbrman = { version = "0.5", optional = true }
 libz-sys = "1"
 
 [build-dependencies]
-shadow-rs = { version = "0.36", features = ["metadata"] }
+shadow-rs = { version = "1", features = ["metadata"] }
 
 [features]
 # This feature should be enabled when building static executable

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,11 @@
-fn main() -> shadow_rs::SdResult<()> {
-    println!("cargo:rerun-if-changed=./");
+use shadow_rs::{BuildPattern, ShadowBuilder};
+
+fn main() {
     let mut deny = std::collections::BTreeSet::new();
     deny.insert(shadow_rs::CARGO_TREE);
-    shadow_rs::new_deny(deny)
+    ShadowBuilder::builder()
+        .build_pattern(BuildPattern::Lazy)
+        .deny_const(deny)
+        .build()
+        .expect("failed to retrieve build info");
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,7 +1,7 @@
 //! Version calculation utilities.
 
-use cargo_metadata::Metadata;
 use serde::Deserialize;
+use shadow_rs::cargo_metadata::{self, Metadata};
 
 shadow_rs::shadow!(build_info);
 


### PR DESCRIPTION
When using `gvltctl --version` gevulot-rs version `unknown` was shown too many times. This PR fixes it.

This metadata trickery was also causing `gvltctl` to constantly re-build. This PR also fixes it by upgrading to new version of `shadow-rs`.